### PR TITLE
:green_heart: CI: Test all packages in the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup component add clippy
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --workspace -- -D warnings
 
   test:
     name: Run tests
@@ -37,7 +37,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: cargo test
+      - run: cargo test --workspace
 
   coverage:
     name: Code coverage


### PR DESCRIPTION
This pull request updates the CI configuration to ensure that all Rust packages
within the workspace are tested, linted, and formatted.
Previously, `cargo test`, `cargo clippy`, and `cargo fmt` commands were
executed without the `--workspace` flag, which meant only the root package
was being processed.

Changes include:
- Added `--workspace` flag to `cargo test` in the `test` job.
- Added `--workspace` flag to `cargo clippy` in the `clippy` job.