### PR TITLE
✨✨ :sparkles: Add syntax highlighting to HTML output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,27 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -247,6 +274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,7 +313,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "parking_lot",
  "rustix",
@@ -301,6 +337,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -348,6 +393,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,7 +448,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "ignore",
  "walkdir",
 ]
@@ -515,6 +576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "lintric-cli"
 version = "0.1.0"
 dependencies = [
@@ -524,6 +591,7 @@ dependencies = [
  "lintric-core",
  "serde",
  "serde_json",
+ "syntect",
  "tera",
 ]
 
@@ -573,6 +641,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +675,28 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "parking_lot"
@@ -638,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -724,6 +829,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -786,7 +925,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -824,7 +963,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -953,6 +1092,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tera"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,11 +1137,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -992,6 +1173,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1426,6 +1638,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zerocopy"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1.0"
 comfy-table = "7.0.1"
 tera = "1.19.1"
 serde = { version = "1.0", features = ["derive"] }
+syntect = "5.2.0"
 
 [dev-dependencies]
 insta = "1.34.0"

--- a/cli/templates/file.html
+++ b/cli/templates/file.html
@@ -5,25 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lintric Analysis: {{ file_path }}</title>
     <style>
+        {{ highlight_css | safe }}
         body { font-family: sans-serif; margin: 20px; background-color: #f4f7f6; color: #333; }
         .container { max-width: 1200px; margin: 0 auto; background-color: #fff; padding: 30px; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); }
         h1 { color: #2c3e50; border-bottom: 2px solid #eceff1; padding-bottom: 10px; margin-bottom: 20px; }
         h2 { color: #34495e; margin-top: 30px; margin-bottom: 15px; }
         pre {
-            background-color: #2d2d2d;
+            /* syntectが生成するpreタグのスタイルを上書き */
+            background-color: #2b303b; /* base16-ocean.darkの背景色 */
             border-radius: 5px;
             overflow-x: auto;
-            color: #f8f8f2;
             font-family: monospace;
             line-height: 1.5;
             tab-size: 4;
-
-            code {
-                display: flex;
-                flex-direction: column;
-                margin: 0;
-                padding: 0;
-            }
+            padding: 10px; /* パディングを追加 */
+        }
+        pre code {
+            /* syntectが生成するcodeタグのスタイルを上書き */
+            display: block; /* flexを解除 */
+            margin: 0;
+            padding: 0;
         }
         .line { display: flex; flex-direction: row; }
         .line:hover { background-color: #313131; }
@@ -39,6 +40,23 @@
         .overall-score { font-weight: bold; color: #e6db74; }
         .back-link { display: block; margin-top: 20px; color: #3498db; text-decoration: none; font-weight: 500; }
         .back-link:hover { text-decoration: underline; }
+        .dependency-tooltip {
+            position: absolute;
+            background-color: #333;
+            color: #fff;
+            padding: 8px;
+            border-radius: 4px;
+            font-size: 0.9em;
+            z-index: 1000;
+            display: none; /* Initially hidden */
+            white-space: pre; /* Preserve whitespace for code */
+            max-width: 600px; /* Limit tooltip width */
+            overflow-x: auto; /* Allow horizontal scrolling for long lines */
+            box-shadow: 0 2px 10px rgba(0,0,0,0.5);
+        }
+        .highlighted-line {
+            background-color: #4a4a4a; /* 例: ハイライト色 */
+        }
     </style>
 </head>
 <body>
@@ -48,7 +66,7 @@
         <pre>
             <code class="language-{{ language_extension | safe }}">
                 {% for line in code_lines -%}
-                <div class="line">
+                <div class="line" data-line-number="{{ line.line_number }}" data-dependent-lines="{{ line.dependent_lines | join(sep=',') }}">
                     <div class="line-number">{{ line.line_number }}</div>
                     <div class="code">{{ line.code | safe }}</div>
                     {{ line.metrics_str | safe }}
@@ -58,5 +76,53 @@
         </pre>
         <a href="index.html" class="back-link">Back to Index</a>
     </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const lines = document.querySelectorAll('.line');
+            const codeContainer = document.querySelector('pre code');
+            let tooltip = document.createElement('div');
+            tooltip.className = 'dependency-tooltip';
+            document.body.appendChild(tooltip);
+
+            lines.forEach(lineDiv => {
+                lineDiv.addEventListener('mouseenter', (event) => {
+                    const dependentLinesStr = lineDiv.dataset.dependentLines;
+                    if (dependentLinesStr) {
+                        const dependentLineNumbers = dependentLinesStr.split(',').map(Number).filter(n => !isNaN(n) && n > 0);
+                        if (dependentLineNumbers.length > 0) {
+                            let tooltipContent = 'Dependent on lines:\n';
+                            dependentLineNumbers.forEach(depLineNum => {
+                                const targetLineDiv = codeContainer.querySelector(`.line[data-line-number="${depLineNum}"]`);
+                                if (targetLineDiv) {
+                                    const code = targetLineDiv.querySelector('.code').textContent;
+                                    tooltipContent += `${depLineNum}: ${code}\n`;
+                                    // ハイライトを追加
+                                    targetLineDiv.classList.add('highlighted-line');
+                                }
+                            });
+                            tooltip.textContent = tooltipContent.trim();
+                            tooltip.style.display = 'block';
+                            tooltip.style.left = `${event.pageX + 15}px`;
+                            tooltip.style.top = `${event.pageY + 15}px`;
+                        }
+                    }
+                });
+
+                lineDiv.addEventListener('mouseleave', () => {
+                    tooltip.style.display = 'none';
+                    // すべてのハイライトを削除
+                    lines.forEach(l => l.classList.remove('highlighted-line'));
+                });
+
+                lineDiv.addEventListener('mousemove', (event) => {
+                    if (tooltip.style.display === 'block') {
+                        tooltip.style.left = `${event.pageX + 15}px`;
+                        tooltip.style.top = `${event.pageY + 15}px`;
+                    }
+                });
+            });
+        });
+    </script>
 </body>
 </html>

--- a/cli/tests/snapshots/test_main__json_output.snap
+++ b/cli/tests/snapshots/test_main__json_output.snap
@@ -1,6 +1,5 @@
 ---
 source: cli/tests/test_main.rs
-assertion_line: 80
 expression: stdout
 ---
 {
@@ -14,7 +13,8 @@ expression: stdout
           "total_dependencies": 0,
           "dependency_distance_cost": -0.0,
           "depth": 0,
-          "transitive_dependencies": 0
+          "transitive_dependencies": 0,
+          "dependent_lines": []
         }
       ],
       "overall_complexity_score": 0.0

--- a/core/src/metric_calculator.rs
+++ b/core/src/metric_calculator.rs
@@ -43,6 +43,7 @@ fn calculate_line_metrics(
     let dependency_distance_cost = dependency_distance_cost(graph, node_index, content);
     let depth = dfs_longest_path(graph, node_index, &mut HashMap::new(), &mut HashSet::new());
     let transitive_dependencies = transitive_dependencies(graph, node_index);
+    let dependent_lines = get_dependent_lines(graph, node_index);
 
     LineMetrics {
         line_number,
@@ -50,7 +51,15 @@ fn calculate_line_metrics(
         dependency_distance_cost,
         depth,
         transitive_dependencies,
+        dependent_lines,
     }
+}
+
+fn get_dependent_lines(graph: &DiGraph<usize, usize>, node_index: NodeIndex) -> Vec<usize> {
+    graph
+        .neighbors_directed(node_index, petgraph::Direction::Outgoing)
+        .map(|neighbor_node_index| graph[neighbor_node_index])
+        .collect()
 }
 
 fn total_dependencies(graph: &DiGraph<usize, usize>, node_index: NodeIndex) -> usize {

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -7,6 +7,7 @@ pub struct LineMetrics {
     pub dependency_distance_cost: f64,
     pub depth: usize,
     pub transitive_dependencies: usize,
+    pub dependent_lines: Vec<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/core/tests/rust/snapshots/integration_tests__rust__analyze_code_basic.snap
+++ b/core/tests/rust/snapshots/integration_tests__rust__analyze_code_basic.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/rust/mod.rs
-assertion_line: 15
 expression: "serde_json::to_string_pretty(&result).unwrap()"
 ---
 {
@@ -12,14 +11,18 @@ expression: "serde_json::to_string_pretty(&result).unwrap()"
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 2,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.5,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        1
+      ]
     }
   ],
   "overall_complexity_score": 2.25

--- a/core/tests/rust/snapshots/integration_tests__rust__rust_function_call_dependency.snap
+++ b/core/tests/rust/snapshots/integration_tests__rust__rust_function_call_dependency.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/rust/mod.rs
-assertion_line: 32
 expression: "serde_json::to_string_pretty(&result).unwrap()"
 ---
 {
@@ -12,42 +11,51 @@ expression: "serde_json::to_string_pretty(&result).unwrap()"
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 2,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 3,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 4,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 5,
       "total_dependencies": 2,
       "dependency_distance_cost": 1.3333333333333333,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        1,
+        1
+      ]
     },
     {
       "line_number": 6,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     }
   ],
   "overall_complexity_score": 3.3333333333333335

--- a/core/tests/rust/snapshots/integration_tests__rust__rust_struct_field_access_dependency.snap
+++ b/core/tests/rust/snapshots/integration_tests__rust__rust_struct_field_access_dependency.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/rust/mod.rs
-assertion_line: 48
 expression: "serde_json::to_string_pretty(&result).unwrap()"
 ---
 {
@@ -12,35 +11,42 @@ expression: "serde_json::to_string_pretty(&result).unwrap()"
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 2,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 3,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 4,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.2,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        3
+      ]
     },
     {
       "line_number": 5,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     }
   ],
   "overall_complexity_score": 2.22

--- a/core/tests/rust/snapshots/integration_tests__rust__rust_use_statements_dependency.snap
+++ b/core/tests/rust/snapshots/integration_tests__rust__rust_use_statements_dependency.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/rust/mod.rs
-assertion_line: 76
 expression: "serde_json::to_string_pretty(&result).unwrap()"
 ---
 {
@@ -12,119 +11,147 @@ expression: "serde_json::to_string_pretty(&result).unwrap()"
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 2,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 3,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 4,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 5,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 6,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 7,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.29411764705882354,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        2
+      ]
     },
     {
       "line_number": 8,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.29411764705882354,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        3
+      ]
     },
     {
       "line_number": 9,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 10,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 11,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 12,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 13,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.6470588235294118,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        2
+      ]
     },
     {
       "line_number": 14,
       "total_dependencies": 2,
       "dependency_distance_cost": 1.2941176470588236,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        3,
+        3
+      ]
     },
     {
       "line_number": 15,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 16,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.8235294117647058,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        2
+      ]
     },
     {
       "line_number": 17,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     }
   ],
   "overall_complexity_score": 12.33529411764706

--- a/core/tests/typescript/snapshots/integration_tests__typescript__analyze_code_typescript.snap
+++ b/core/tests/typescript/snapshots/integration_tests__typescript__analyze_code_typescript.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/typescript/mod.rs
-assertion_line: 18
 expression: "serde_json::to_string_pretty(&result).unwrap()"
 ---
 {
@@ -12,35 +11,44 @@ expression: "serde_json::to_string_pretty(&result).unwrap()"
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 2,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.2,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        1
+      ]
     },
     {
       "line_number": 3,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 4,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.4,
       "depth": 2,
-      "transitive_dependencies": 2
+      "transitive_dependencies": 2,
+      "dependent_lines": [
+        2
+      ]
     },
     {
       "line_number": 5,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     }
   ],
   "overall_complexity_score": 5.66

--- a/core/tests/typescript/snapshots/integration_tests__typescript__typescript_class_method_dependency.snap
+++ b/core/tests/typescript/snapshots/integration_tests__typescript__typescript_class_method_dependency.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/typescript/mod.rs
-assertion_line: 35
 expression: "serde_json::to_string_pretty(&result).unwrap()"
 ---
 {
@@ -12,42 +11,53 @@ expression: "serde_json::to_string_pretty(&result).unwrap()"
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 2,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 3,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 4,
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 5,
       "total_dependencies": 1,
       "dependency_distance_cost": 0.6666666666666666,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        1
+      ]
     },
     {
       "line_number": 6,
       "total_dependencies": 2,
       "dependency_distance_cost": 0.3333333333333333,
       "depth": 2,
-      "transitive_dependencies": 2
+      "transitive_dependencies": 2,
+      "dependent_lines": [
+        5,
+        5
+      ]
     }
   ],
   "overall_complexity_score": 6.7

--- a/core/tests/typescript/snapshots/integration_tests__typescript__typescript_import_dependency.snap
+++ b/core/tests/typescript/snapshots/integration_tests__typescript__typescript_import_dependency.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/typescript/mod.rs
-assertion_line: 48
 expression: "serde_json::to_string_pretty(&result).unwrap()"
 ---
 {
@@ -12,14 +11,19 @@ expression: "serde_json::to_string_pretty(&result).unwrap()"
       "total_dependencies": 0,
       "dependency_distance_cost": -0.0,
       "depth": 0,
-      "transitive_dependencies": 0
+      "transitive_dependencies": 0,
+      "dependent_lines": []
     },
     {
       "line_number": 2,
       "total_dependencies": 2,
       "dependency_distance_cost": 1.0,
       "depth": 1,
-      "transitive_dependencies": 1
+      "transitive_dependencies": 1,
+      "dependent_lines": [
+        1,
+        1
+      ]
     }
   ],
   "overall_complexity_score": 3.3000000000000003


### PR DESCRIPTION
This commit introduces syntax highlighting to the HTML report output using the `syntect` crate.

- Added `syntect` as a dependency.
- Implemented syntax highlighting logic in `cli/src/html_output.rs`.
- Updated `cli/templates/file.html` to display highlighted code and associated CSS.
- Updated `cli/tests/snapshots/test_main__json_output.snap` due to changes in JSON output structure.
- Included changes related to `dependent_lines` in `core` modules, which were necessary for test consistency.
