### PR TITLE
:+1: Filter out zero-metric records in JSON output

### DIFF
--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -4,7 +4,32 @@ use lintric_core::models::OverallAnalysisReport;
 
 /// Display the analysis results in JSON format
 pub fn display_json(overall_report: &OverallAnalysisReport) {
-    println!("{}", serde_json::to_string_pretty(overall_report).unwrap());
+    #[derive(serde::Serialize)]
+    struct JsonReport {
+        results: Vec<lintric_core::models::AnalysisResult>,
+        total_files_analyzed: usize,
+        total_overall_complexity_score: f64,
+        average_complexity_score: f64,
+    }
+
+    let mut filtered_results = overall_report.results.clone();
+    for result in &mut filtered_results {
+        result
+            .line_metrics
+            .retain(|metrics| metrics.total_dependencies > 0);
+    }
+
+    let report_for_json = JsonReport {
+        results: filtered_results,
+        total_files_analyzed: overall_report.total_files_analyzed,
+        total_overall_complexity_score: overall_report.total_overall_complexity_score,
+        average_complexity_score: overall_report.average_complexity_score,
+    };
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report_for_json).unwrap()
+    );
 }
 
 /// Display verbose analysis results with line-by-line metrics

--- a/cli/tests/snapshots/test_main__json_output.snap
+++ b/cli/tests/snapshots/test_main__json_output.snap
@@ -5,13 +5,126 @@ expression: stdout
 {
   "results": [
     {
-      "file_path": "tmp/temp_test_file_json.rs",
-      "original_file_path": "tmp/temp_test_file_json.rs",
-      "line_metrics": [],
-      "overall_complexity_score": 0.0
+      "file_path": "../core/tests/rust/fixtures/complex_rust_code.rs",
+      "original_file_path": "../core/tests/rust/fixtures/complex_rust_code.rs",
+      "line_metrics": [
+        {
+          "line_number": 7,
+          "total_dependencies": 2,
+          "dependency_distance_cost": 0.0625,
+          "depth": 1,
+          "transitive_dependencies": 1,
+          "dependent_lines": [
+            6,
+            6
+          ]
+        },
+        {
+          "line_number": 8,
+          "total_dependencies": 1,
+          "dependency_distance_cost": 0.03125,
+          "depth": 2,
+          "transitive_dependencies": 2,
+          "dependent_lines": [
+            7
+          ]
+        },
+        {
+          "line_number": 16,
+          "total_dependencies": 6,
+          "dependency_distance_cost": 1.46875,
+          "depth": 1,
+          "transitive_dependencies": 4,
+          "dependent_lines": [
+            13,
+            26,
+            12,
+            26,
+            6,
+            6
+          ]
+        },
+        {
+          "line_number": 17,
+          "total_dependencies": 6,
+          "dependency_distance_cost": 1.59375,
+          "depth": 2,
+          "transitive_dependencies": 5,
+          "dependent_lines": [
+            13,
+            27,
+            12,
+            27,
+            6,
+            6
+          ]
+        },
+        {
+          "line_number": 22,
+          "total_dependencies": 1,
+          "dependency_distance_cost": 0.03125,
+          "depth": 1,
+          "transitive_dependencies": 1,
+          "dependent_lines": [
+            21
+          ]
+        },
+        {
+          "line_number": 23,
+          "total_dependencies": 1,
+          "dependency_distance_cost": 0.03125,
+          "depth": 2,
+          "transitive_dependencies": 2,
+          "dependent_lines": [
+            22
+          ]
+        },
+        {
+          "line_number": 27,
+          "total_dependencies": 1,
+          "dependency_distance_cost": 0.03125,
+          "depth": 1,
+          "transitive_dependencies": 1,
+          "dependent_lines": [
+            26
+          ]
+        },
+        {
+          "line_number": 28,
+          "total_dependencies": 2,
+          "dependency_distance_cost": 0.09375,
+          "depth": 2,
+          "transitive_dependencies": 2,
+          "dependent_lines": [
+            26,
+            27
+          ]
+        },
+        {
+          "line_number": 30,
+          "total_dependencies": 1,
+          "dependency_distance_cost": 0.46875,
+          "depth": 1,
+          "transitive_dependencies": 1,
+          "dependent_lines": [
+            15
+          ]
+        },
+        {
+          "line_number": 31,
+          "total_dependencies": 1,
+          "dependency_distance_cost": 0.34375,
+          "depth": 1,
+          "transitive_dependencies": 1,
+          "dependent_lines": [
+            20
+          ]
+        }
+      ],
+      "overall_complexity_score": 40.415625000000006
     }
   ],
   "total_files_analyzed": 1,
-  "total_overall_complexity_score": 0.0,
-  "average_complexity_score": 0.0
+  "total_overall_complexity_score": 40.415625000000006,
+  "average_complexity_score": 40.415625000000006
 }

--- a/cli/tests/snapshots/test_main__json_output.snap
+++ b/cli/tests/snapshots/test_main__json_output.snap
@@ -7,16 +7,7 @@ expression: stdout
     {
       "file_path": "tmp/temp_test_file_json.rs",
       "original_file_path": "tmp/temp_test_file_json.rs",
-      "line_metrics": [
-        {
-          "line_number": 1,
-          "total_dependencies": 0,
-          "dependency_distance_cost": -0.0,
-          "depth": 0,
-          "transitive_dependencies": 0,
-          "dependent_lines": []
-        }
-      ],
+      "line_metrics": [],
       "overall_complexity_score": 0.0
     }
   ],

--- a/cli/tests/snapshots/test_main__multiple_files_analysis.snap.new
+++ b/cli/tests/snapshots/test_main__multiple_files_analysis.snap.new
@@ -1,5 +1,6 @@
 ---
 source: cli/tests/test_main.rs
+assertion_line: 55
 expression: stdout
 ---
 ┌───────────────────┬──────────────────────────┐

--- a/cli/tests/test_main.rs
+++ b/cli/tests/test_main.rs
@@ -57,11 +57,7 @@ fn test_multiple_files_analysis() {
 
 #[test]
 fn test_json_output() {
-    let temp_dir = PathBuf::from("tmp");
-    fs::create_dir_all(&temp_dir).expect("Unable to create test directory");
-
-    let temp_file_path = temp_dir.join("temp_test_file_json.rs");
-    fs::write(&temp_file_path, "let val = 10;").expect("Unable to write test file");
+    let fixture_path = "../core/tests/rust/fixtures/complex_rust_code.rs";
 
     let output = Command::new("cargo")
         .arg("run")
@@ -69,7 +65,7 @@ fn test_json_output() {
         .arg("lintric-cli")
         .arg("--")
         .arg("--json")
-        .arg(temp_file_path.to_string_lossy().replace("\\", "/"))
+        .arg(fixture_path)
         .output()
         .expect("Failed to execute command");
 


### PR DESCRIPTION
This change modifies the JSON output to exclude line metric records where the `total_dependencies` is zero.

This makes the output cleaner and more focused on lines with actual complexity, improving readability for users and tools that consume the JSON data.

Fixes #43
Fixes E-491