### PR TITLE
:sparkles: Add Rust Closure support

### DIFF
--- a/core/src/collectors/common/definition_collectors.rs
+++ b/core/src/collectors/common/definition_collectors.rs
@@ -57,6 +57,12 @@ pub trait DefinitionCollector {
         source_code: &str,
         definitions: &mut HashMap<String, usize>,
     );
+
+    fn collect_closure_definitions(
+        node: Node,
+        source_code: &str,
+        definitions: &mut HashMap<String, usize>,
+    );
 }
 
 pub fn find_identifiers_in_pattern(

--- a/core/src/collectors/rust/rust_definition_collector.rs
+++ b/core/src/collectors/rust/rust_definition_collector.rs
@@ -26,6 +26,7 @@ impl DefinitionCollector for RustDefinitionCollector {
         kind_handlers.insert("impl_item", Self::collect_type_definitions);
         kind_handlers.insert("type_alias", Self::collect_type_definitions);
         kind_handlers.insert("use_declaration", Self::collect_import_definitions);
+        kind_handlers.insert("closure_expression", Self::collect_closure_definitions);
 
         Self::collect_definitions_recursive(root, content, &mut definitions, &kind_handlers);
         Ok(definitions)
@@ -143,6 +144,19 @@ impl DefinitionCollector for RustDefinitionCollector {
                     }
                 }
                 _ => {}
+            }
+        }
+    }
+
+    fn collect_closure_definitions(
+        node: Node,
+        source_code: &str,
+        definitions: &mut HashMap<String, usize>,
+    ) {
+        if let Some(parameters_node) = node.child_by_field_name("parameters") {
+            let mut param_cursor = parameters_node.walk();
+            for param_child in parameters_node.children(&mut param_cursor) {
+                find_identifiers_in_pattern(param_child, source_code, definitions);
             }
         }
     }

--- a/core/src/collectors/typescript/typescript_definition_collector.rs
+++ b/core/src/collectors/typescript/typescript_definition_collector.rs
@@ -160,4 +160,12 @@ impl DefinitionCollector for TypescriptDefinitionCollector {
             }
         }
     }
+
+    fn collect_closure_definitions(
+        _node: Node,
+        _source_code: &str,
+        _definitions: &mut HashMap<String, usize>,
+    ) {
+        // Arrow functions are handled by collect_variable_definitions
+    }
 }

--- a/core/tests/rust/fixtures/closure_dependency.rs
+++ b/core/tests/rust/fixtures/closure_dependency.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let add_one = |x| x + 1;
+    let y = 2;
+    add_one(y);
+}

--- a/core/tests/rust/mod.rs
+++ b/core/tests/rust/mod.rs
@@ -75,3 +75,12 @@ fn main() {
 
     assert_snapshot!(serde_json::to_string_pretty(&result).unwrap());
 }
+
+#[test]
+fn test_rust_closure_dependency() {
+    let code = include_str!("fixtures/closure_dependency.rs");
+    let file_path = "fixtures/closure_dependency.rs".to_string();
+    let result = analyze_code(code, file_path.clone(), file_path.clone()).unwrap();
+
+    assert_snapshot!(serde_json::to_string_pretty(&result).unwrap());
+}

--- a/core/tests/rust/snapshots/integration_tests__rust__rust_closure_dependency.snap
+++ b/core/tests/rust/snapshots/integration_tests__rust__rust_closure_dependency.snap
@@ -1,0 +1,64 @@
+---
+source: core/tests/rust/mod.rs
+assertion_line: 85
+expression: "serde_json::to_string_pretty(&result).unwrap()"
+---
+{
+  "file_path": "fixtures/closure_dependency.rs",
+  "original_file_path": "fixtures/closure_dependency.rs",
+  "line_metrics": [
+    {
+      "line_number": 1,
+      "total_dependencies": 0,
+      "dependency_distance_cost": -0.0,
+      "depth": 0,
+      "transitive_dependencies": 0,
+      "dependent_lines": []
+    },
+    {
+      "line_number": 2,
+      "total_dependencies": 0,
+      "dependency_distance_cost": -0.0,
+      "depth": 0,
+      "transitive_dependencies": 0,
+      "dependent_lines": []
+    },
+    {
+      "line_number": 3,
+      "total_dependencies": 0,
+      "dependency_distance_cost": -0.0,
+      "depth": 0,
+      "transitive_dependencies": 0,
+      "dependent_lines": []
+    },
+    {
+      "line_number": 4,
+      "total_dependencies": 3,
+      "dependency_distance_cost": 1.0,
+      "depth": 1,
+      "transitive_dependencies": 2,
+      "dependent_lines": [
+        3,
+        2,
+        2
+      ]
+    },
+    {
+      "line_number": 5,
+      "total_dependencies": 0,
+      "dependency_distance_cost": -0.0,
+      "depth": 0,
+      "transitive_dependencies": 0,
+      "dependent_lines": []
+    },
+    {
+      "line_number": 6,
+      "total_dependencies": 0,
+      "dependency_distance_cost": -0.0,
+      "depth": 0,
+      "transitive_dependencies": 0,
+      "dependent_lines": []
+    }
+  ],
+  "overall_complexity_score": 4.5
+}


### PR DESCRIPTION
Rust: Count closure parameters as definitions

This commit addresses issue #47, where closure parameters were not being counted as definitions.

- Added `collect_closure_definitions` to the `DefinitionCollector` trait.
- Implemented `collect_closure_definitions` for the `RustDefinitionCollector` to correctly identify and register closure parameters.
- Added a new test case with a snapshot to verify that closure parameters and their dependencies are now correctly analyzed.
