### PR TITLE
Fix destructuring patterns not recording individual definitions

### DIFF
--- a/core/src/collectors/typescript/typescript_definition_collector.rs
+++ b/core/src/collectors/typescript/typescript_definition_collector.rs
@@ -65,14 +65,22 @@ impl<'a> DefinitionCollector<'a> for TypescriptDefinitionCollector<'a> {
         node: Node<'a>,
         current_scope: &Option<String>,
     ) -> Vec<Definition> {
-        Definition::from_naming_node(
-            &node,
-            self.source_code,
-            DefinitionType::VariableDefinition,
-            current_scope.clone(),
-        )
-        .into_iter()
-        .collect()
+        // For variable_declarator, extract identifiers from patterns (array_pattern, object_pattern, etc.)
+        if let Some(name_node) = node.child_by_field_name("name") {
+            find_identifier_nodes_in_node(name_node)
+                .iter()
+                .map(|identifier_node| {
+                    Definition::new(
+                        identifier_node,
+                        self.source_code,
+                        DefinitionType::VariableDefinition,
+                        current_scope.clone(),
+                    )
+                })
+                .collect()
+        } else {
+            vec![]
+        }
     }
 
     fn collect_function_definitions(

--- a/generated-tests/tests/snapshots/rust/test_generated_captured_pattern.snap
+++ b/generated-tests/tests/snapshots/rust/test_generated_captured_pattern.snap
@@ -30,7 +30,14 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition {
+            name: "y1",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+    ],
     dependencies: [],
     usage: [
         SerializableUsage {

--- a/generated-tests/tests/snapshots/rust/test_generated_match_expression.snap
+++ b/generated-tests/tests/snapshots/rust/test_generated_match_expression.snap
@@ -34,7 +34,14 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition {
+            name: "x7",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+    ],
     dependencies: [],
     usage: [
         SerializableUsage {

--- a/generated-tests/tests/snapshots/rust/test_generated_token_binding_pattern.snap
+++ b/generated-tests/tests/snapshots/rust/test_generated_token_binding_pattern.snap
@@ -27,7 +27,14 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition {
+            name: "b4",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+    ],
     dependencies: [],
     usage: [
         SerializableUsage {

--- a/generated-tests/tests/snapshots/ts/test_generated_array_pattern.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_array_pattern.snap
@@ -23,7 +23,13 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "[a, b]",
+            name: "a",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "b",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/ts/test_generated_object_assignment_pattern.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_object_assignment_pattern.snap
@@ -25,7 +25,7 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ prop3 = defaultVal }",
+            name: "prop3",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,
@@ -33,6 +33,15 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
+        SerializableUsage {
+            name: "defaultVal",
+            kind: Identifier,
+            scope: None,
+            start_line: 1,
+            start_column: 17,
+            end_line: 1,
+            end_column: 27,
+        },
         SerializableUsage {
             name: "obj2",
             kind: Identifier,

--- a/generated-tests/tests/snapshots/ts/test_generated_object_pattern.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_object_pattern.snap
@@ -23,7 +23,13 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ prop12, prop21 }",
+            name: "prop12",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "prop21",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/ts/test_generated_pair_pattern.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_pair_pattern.snap
@@ -25,7 +25,7 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ key1: value18 }",
+            name: "value18",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/ts/test_generated_rest_pattern.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_rest_pattern.snap
@@ -25,7 +25,13 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "[first, ...rest]",
+            name: "first",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "rest",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/ts/test_generated_shorthand_property_identifier_pattern.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_shorthand_property_identifier_pattern.snap
@@ -22,7 +22,7 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ prop6 }",
+            name: "prop6",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/tsx/test_generated_array_pattern.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_array_pattern.snap
@@ -23,7 +23,13 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "[a, b]",
+            name: "a",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "b",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/tsx/test_generated_object_assignment_pattern.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_object_assignment_pattern.snap
@@ -25,7 +25,7 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ prop5 = defaultVal }",
+            name: "prop5",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,
@@ -33,6 +33,15 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
+        SerializableUsage {
+            name: "defaultVal",
+            kind: Identifier,
+            scope: None,
+            start_line: 1,
+            start_column: 17,
+            end_line: 1,
+            end_column: 27,
+        },
         SerializableUsage {
             name: "obj2",
             kind: Identifier,

--- a/generated-tests/tests/snapshots/tsx/test_generated_object_pattern.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_object_pattern.snap
@@ -23,7 +23,13 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ prop12, prop22 }",
+            name: "prop12",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "prop22",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/tsx/test_generated_pair_pattern.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_pair_pattern.snap
@@ -25,7 +25,7 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ key1: value22 }",
+            name: "value22",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/tsx/test_generated_rest_pattern.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_rest_pattern.snap
@@ -25,7 +25,13 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "[first, ...rest]",
+            name: "first",
+            line_number: 1,
+            definition_type: VariableDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "rest",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,

--- a/generated-tests/tests/snapshots/tsx/test_generated_shorthand_property_identifier_pattern.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_shorthand_property_identifier_pattern.snap
@@ -22,7 +22,7 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition {
-            name: "{ prop8 }",
+            name: "prop8",
             line_number: 1,
             definition_type: VariableDefinition,
             scope: None,


### PR DESCRIPTION
## Summary
- Fixes issue #74 where destructuring patterns were not recording individual variable definitions
- Improves accuracy of definition tracking for TypeScript/TSX array and object destructuring
- Enhances Rust match pattern processing to distinguish between variable bindings and value comparisons
- Ensures default values in assignment patterns are correctly recorded as usage, not definitions

## Changes Made

### TypeScript/TSX Improvements
- **Array destructuring**: `const [a, b] = array` now correctly records `a` and `b` as separate definitions
- **Object destructuring**: `const {prop1, prop2} = obj` now correctly records `prop1` and `prop2` as separate definitions  
- **Assignment patterns**: `const {prop = defaultVal} = obj` now correctly excludes `defaultVal` from definitions and records it as usage

### Rust Improvements
- **Match expressions**: Enhanced pattern binding extraction to avoid recording constructors as definitions
- **Pattern matching**: `match val { Some(x) => x }` now correctly records only `x` as definition, excluding `Some`
- **Conservative approach**: Simple identifier patterns like `match val { x => {} }` are treated as usage to avoid false positives
- **Captured patterns**: `var @ pattern` correctly extracts `var` as a binding

### Technical Implementation
- Extended `find_identifier_nodes_in_node` function with specialized handling for assignment patterns
- Added `extract_pattern_bindings` methods for precise Rust pattern variable extraction
- Enhanced TypeScript usage collector with special case handling for assignment pattern default values
- Improved constructor vs variable binding distinction logic

## Test Plan
- [x] All existing tests pass (505 tests)
- [x] Updated snapshot tests reflect correct behavior
- [x] Verified TypeScript array destructuring works correctly
- [x] Verified TypeScript object destructuring works correctly  
- [x] Verified Rust match pattern processing works correctly
- [x] Verified assignment pattern default values are recorded as usage
- [x] No regressions in other pattern types

close: #74 
close: E-513

🤖 Generated with [Claude Code](https://claude.ai/code)