### PR TITLE
feat: add class/interface member and method definition tracking

### DIFF
--- a/cli/tests/snapshots/test_main__debug_ir_typescript.snap
+++ b/cli/tests/snapshots/test_main__debug_ir_typescript.snap
@@ -24,6 +24,18 @@ expression: out
       "scope": "Point"
     },
     {
+      "name": "x",
+      "line_number": 6,
+      "definition_type": "PropertyDefinition",
+      "scope": "Point"
+    },
+    {
+      "name": "y",
+      "line_number": 7,
+      "definition_type": "PropertyDefinition",
+      "scope": "Point"
+    },
+    {
       "name": "add",
       "line_number": 10,
       "definition_type": "FunctionDefinition",

--- a/core/src/models/definition.rs
+++ b/core/src/models/definition.rs
@@ -13,6 +13,8 @@ pub enum DefinitionType {
     ConstDefinition,
     MacroDefinition,
     MacroVariableDefinition,
+    PropertyDefinition,
+    MethodDefinition,
     Other(String),
 }
 

--- a/core/tests/typescript/snapshots/integration_tests__typescript__class_method_dependency_ir.snap
+++ b/core/tests/typescript/snapshots/integration_tests__typescript__class_method_dependency_ir.snap
@@ -14,7 +14,7 @@ expression: "serde_json::to_string_pretty(&ir).unwrap()"
     {
       "name": "constructor",
       "line_number": 2,
-      "definition_type": "FunctionDefinition",
+      "definition_type": "MethodDefinition",
       "scope": "MyClass"
     },
     {
@@ -26,7 +26,7 @@ expression: "serde_json::to_string_pretty(&ir).unwrap()"
     {
       "name": "greet",
       "line_number": 3,
-      "definition_type": "FunctionDefinition",
+      "definition_type": "MethodDefinition",
       "scope": "MyClass"
     },
     {

--- a/generated-tests/tests/snapshots/ts/test_generated_class_declaration.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_class_declaration.snap
@@ -51,9 +51,17 @@ IntermediateRepresentation {
             ),
         },
         Definition {
+            name: "field",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: Some(
+                "TestClass1",
+            ),
+        },
+        Definition {
             name: "method1",
             line_number: 1,
-            definition_type: FunctionDefinition,
+            definition_type: MethodDefinition,
             scope: Some(
                 "TestClass1",
             ),

--- a/generated-tests/tests/snapshots/ts/test_generated_interface_declaration.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_interface_declaration.snap
@@ -39,6 +39,22 @@ IntermediateRepresentation {
                 "TestInterface",
             ),
         },
+        Definition {
+            name: "prop",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: Some(
+                "TestInterface",
+            ),
+        },
+        Definition {
+            name: "method2",
+            line_number: 1,
+            definition_type: MethodDefinition,
+            scope: Some(
+                "TestInterface",
+            ),
+        },
     ],
     dependencies: [],
     usage: [

--- a/generated-tests/tests/snapshots/ts/test_generated_intersection_type.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_intersection_type.snap
@@ -56,6 +56,18 @@ IntermediateRepresentation {
             definition_type: VariableDefinition,
             scope: None,
         },
+        Definition {
+            name: "a",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "b",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
     ],
     dependencies: [],
     usage: [

--- a/generated-tests/tests/snapshots/ts/test_generated_lookup_type.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_lookup_type.snap
@@ -49,6 +49,12 @@ IntermediateRepresentation {
             scope: None,
         },
         Definition {
+            name: "key",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
+        Definition {
             name: "value14",
             line_number: 1,
             definition_type: VariableDefinition,

--- a/generated-tests/tests/snapshots/ts/test_generated_object_type.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_object_type.snap
@@ -40,6 +40,12 @@ IntermediateRepresentation {
             definition_type: VariableDefinition,
             scope: None,
         },
+        Definition {
+            name: "prop4",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
     ],
     dependencies: [],
     usage: [

--- a/generated-tests/tests/snapshots/ts/test_generated_this_type.snap
+++ b/generated-tests/tests/snapshots/ts/test_generated_this_type.snap
@@ -41,7 +41,7 @@ IntermediateRepresentation {
         Definition {
             name: "method3",
             line_number: 1,
-            definition_type: FunctionDefinition,
+            definition_type: MethodDefinition,
             scope: Some(
                 "TestClass3",
             ),

--- a/generated-tests/tests/snapshots/tsx/test_generated_class_declaration.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_class_declaration.snap
@@ -51,9 +51,17 @@ IntermediateRepresentation {
             ),
         },
         Definition {
+            name: "field",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: Some(
+                "TestClass1",
+            ),
+        },
+        Definition {
             name: "method1",
             line_number: 1,
-            definition_type: FunctionDefinition,
+            definition_type: MethodDefinition,
             scope: Some(
                 "TestClass1",
             ),

--- a/generated-tests/tests/snapshots/tsx/test_generated_interface_declaration.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_interface_declaration.snap
@@ -39,6 +39,22 @@ IntermediateRepresentation {
                 "TestInterface",
             ),
         },
+        Definition {
+            name: "prop",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: Some(
+                "TestInterface",
+            ),
+        },
+        Definition {
+            name: "method2",
+            line_number: 1,
+            definition_type: MethodDefinition,
+            scope: Some(
+                "TestInterface",
+            ),
+        },
     ],
     dependencies: [],
     usage: [

--- a/generated-tests/tests/snapshots/tsx/test_generated_intersection_type.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_intersection_type.snap
@@ -56,6 +56,18 @@ IntermediateRepresentation {
             definition_type: VariableDefinition,
             scope: None,
         },
+        Definition {
+            name: "a",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
+        Definition {
+            name: "b",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
     ],
     dependencies: [],
     usage: [

--- a/generated-tests/tests/snapshots/tsx/test_generated_lookup_type.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_lookup_type.snap
@@ -49,6 +49,12 @@ IntermediateRepresentation {
             scope: None,
         },
         Definition {
+            name: "key",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
+        Definition {
             name: "value18",
             line_number: 1,
             definition_type: VariableDefinition,

--- a/generated-tests/tests/snapshots/tsx/test_generated_object_type.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_object_type.snap
@@ -40,6 +40,12 @@ IntermediateRepresentation {
             definition_type: VariableDefinition,
             scope: None,
         },
+        Definition {
+            name: "prop6",
+            line_number: 1,
+            definition_type: PropertyDefinition,
+            scope: None,
+        },
     ],
     dependencies: [],
     usage: [

--- a/generated-tests/tests/snapshots/tsx/test_generated_this_type.snap
+++ b/generated-tests/tests/snapshots/tsx/test_generated_this_type.snap
@@ -41,7 +41,7 @@ IntermediateRepresentation {
         Definition {
             name: "method3",
             line_number: 1,
-            definition_type: FunctionDefinition,
+            definition_type: MethodDefinition,
             scope: Some(
                 "TestClass3",
             ),


### PR DESCRIPTION
## Summary
- Add support for tracking class fields, interface properties, and methods as proper definitions
- Introduce PropertyDefinition and MethodDefinition types to distinguish member types
- Fix issue where class/interface members were missing from IR definitions

## Changes
- Add PropertyDefinition and MethodDefinition to DefinitionType enum
- Extend TypeScript definition collector to handle class field definitions
- Add support for interface property and method signature collection
- Properly classify method_definition nodes as MethodDefinition instead of FunctionDefinition
- Update all affected test snapshots to reflect new definition tracking

## Test plan
- [x] All existing tests pass
- [x] Class field definitions are now properly collected
- [x] Interface property and method definitions are tracked
- [x] Method definitions are correctly classified as MethodDefinition
- [x] Snapshot tests updated to verify correct behavior

Fixes #76

🤖 Generated with [Claude Code](https://claude.ai/code)