### PR TITLE
fix(ci): resolve clippy question-mark lint and audit vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -882,9 +882,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/crates/core/src/languages/rust/dependency_resolver/module_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/module_resolver.rs
@@ -249,23 +249,14 @@ impl ImportResolver {
         let mut current_module = from_module;
 
         for part in parts {
-            if let Some(module) = self.module_tree.modules.get(&current_module) {
-                let child_id = module.children.iter().find(|&&child_id| {
-                    if let Some(child) = self.module_tree.modules.get(&child_id) {
-                        child.name == part
-                    } else {
-                        false
-                    }
-                });
-
-                if let Some(&child_id) = child_id {
-                    current_module = child_id;
-                } else {
-                    return None;
-                }
-            } else {
-                return None;
-            }
+            let module = self.module_tree.modules.get(&current_module)?;
+            let &child_id = module.children.iter().find(|&&child_id| {
+                self.module_tree
+                    .modules
+                    .get(&child_id)
+                    .is_some_and(|child| child.name == part)
+            })?;
+            current_module = child_id;
         }
 
         Some(current_module)


### PR DESCRIPTION
## Summary
- Rewrite `resolve_relative_path` in `module_resolver.rs` using `?` to silence `clippy::question_mark` (newly enforced under Rust 1.97, blocking CI on `main`).
- Bump transitive deps in `Cargo.lock` to clear three RustSec advisories the audit job was failing on:
  - `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)
  - `plist` 1.7.4 → 1.10.0, which pulls in `quick-xml` 0.38.1 → 0.41.0 (RUSTSEC-2026-0194 / 0195)

The three remaining `cargo audit` messages (bincode / yaml-rust / rand) are unmaintained-warning level only and do not fail the job.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo audit` (exit 0; 3 warnings, 0 vulnerabilities)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal module path resolution logic while preserving existing behavior.
  * Unresolvable module paths continue to return no result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->