### PR TITLE
chore(deps): bump tree-sitter stack (0.25) and grammar crates together

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -49,29 +49,23 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -90,21 +84,25 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -137,20 +135,20 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
@@ -165,13 +163,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -211,9 +209,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "document-features"
@@ -238,19 +233,25 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -260,9 +261,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -282,24 +283,29 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -309,12 +315,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -331,21 +337,21 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
 
 [[package]]
 name = "linked-hash-map"
@@ -375,6 +381,7 @@ dependencies = [
  "petgraph",
  "serde",
  "serde_json",
+ "streaming-iterator",
  "tree-sitter",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -396,9 +403,9 @@ version = "0.1.0"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litrs"
@@ -408,19 +415,18 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -429,31 +435,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags",
  "libc",
@@ -463,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -473,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -483,15 +490,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -501,16 +508,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "serde",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
@@ -533,9 +540,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -551,33 +558,33 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -587,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -598,21 +605,21 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -657,7 +664,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.1",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -666,12 +673,25 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -681,9 +701,15 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -693,9 +719,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -704,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -736,15 +762,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -758,32 +784,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -793,15 +818,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -809,51 +834,61 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.22.6"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-rust"
-version = "0.21.2"
+name = "tree-sitter-language"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277690f420bf90741dea984f3da038ace46c4fe6047cba57a66822226cde1c93"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.21.2"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb35d98a688378e56c18c9c159824fd16f730ccbea19aacf4f206e5d5438ed9"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -869,15 +904,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
 ]
 
 [[package]]
@@ -898,11 +924,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -913,33 +939,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
-]
 
 [[package]]
 name = "windows-sys"
@@ -947,143 +949,8 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "yaml-rust"
@@ -1096,6 +963,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2021"
 petgraph = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tree-sitter = "0.22.6"
-tree-sitter-rust = "0.21.2"
-tree-sitter-typescript = "0.21.1"
+tree-sitter = "0.25.10"
+tree-sitter-rust = "0.24.2"
+tree-sitter-typescript = "0.23.2"
+streaming-iterator = "0.1"
 
 [dev-dependencies]
 insta = "1.47.2"

--- a/crates/core/src/languages/rust/dependency_resolver/impl_collector.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/impl_collector.rs
@@ -2,6 +2,7 @@ use crate::languages::rust::dependency_resolver::method_resolver::{
     ImplBlock, ImplBlockId, TraitDef, TraitId, TraitImpl, TraitImplId,
 };
 use crate::models::{Definition, DefinitionType, Position, Type};
+use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Query, QueryCursor};
 
 pub struct RustImplCollector {
@@ -34,15 +35,15 @@ impl RustImplCollector {
             ) @impl_block
         "#;
 
-        let language = tree_sitter_rust::language();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
         let query = Query::new(&language, query_str)
             .map_err(|e| format!("Failed to create impl query: {}", e))?;
 
         let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, root_node, source_code.as_bytes());
+        let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
 
-        for match_ in matches {
-            if let Some(impl_block) = self.parse_impl_block(&match_, source_code) {
+        while let Some(match_) = matches.next() {
+            if let Some(impl_block) = self.parse_impl_block(match_, source_code) {
                 impl_blocks.push(impl_block);
             }
         }
@@ -66,15 +67,15 @@ impl RustImplCollector {
             ) @trait_impl
         "#;
 
-        let language = tree_sitter_rust::language();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
         let query = Query::new(&language, query_str)
             .map_err(|e| format!("Failed to create trait impl query: {}", e))?;
 
         let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, root_node, source_code.as_bytes());
+        let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
 
-        for match_ in matches {
-            if let Some(trait_impl) = self.parse_trait_impl(&match_, source_code) {
+        while let Some(match_) = matches.next() {
+            if let Some(trait_impl) = self.parse_trait_impl(match_, source_code) {
                 trait_impls.push(trait_impl);
             }
         }
@@ -97,15 +98,15 @@ impl RustImplCollector {
             ) @trait_def
         "#;
 
-        let language = tree_sitter_rust::language();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
         let query = Query::new(&language, query_str)
             .map_err(|e| format!("Failed to create trait query: {}", e))?;
 
         let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, root_node, source_code.as_bytes());
+        let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
 
-        for match_ in matches {
-            if let Some(trait_def) = self.parse_trait_def(&match_, source_code) {
+        while let Some(match_) = matches.next() {
+            if let Some(trait_def) = self.parse_trait_def(match_, source_code) {
                 traits.push(trait_def);
             }
         }

--- a/crates/core/src/models/language.rs
+++ b/crates/core/src/models/language.rs
@@ -1,7 +1,5 @@
 use std::path::Path;
 use tree_sitter::Language as TreeSitterLanguage;
-use tree_sitter_rust;
-use tree_sitter_typescript;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Language {
@@ -24,9 +22,9 @@ impl Language {
 
     pub fn get_tree_sitter_language(&self) -> TreeSitterLanguage {
         match self {
-            Language::Rust => tree_sitter_rust::language(),
-            Language::TypeScript => tree_sitter_typescript::language_typescript(),
-            Language::TSX => tree_sitter_typescript::language_tsx(),
+            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Language::TSX => tree_sitter_typescript::LANGUAGE_TSX.into(),
         }
     }
 }

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_advanced_generics_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_advanced_generics_ir.snap
@@ -71,8 +71,8 @@ AST:
   (function_item
     name: (identifier "process_item")
     type_parameters: (type_parameters
-      (constrained_type_parameter
-        left: (type_identifier "T")
+      (type_parameter
+        name: (type_identifier "T")
         bounds: (trait_bounds
           (type_identifier "Clone")
           (type_identifier "Display")
@@ -236,7 +236,6 @@ IntermediateRepresentation {
         Definition { position: { 32:9 to 32:15 }, name: "result", definition_type: VariableDefinition, scope_id: Some(13), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [
-        Dependency { source_line: 9, target_line: 1, symbol: "Clone", dependency_type: TypeReference, context: Some("TypeIdentifier:9:20") },
         Dependency { source_line: 9, target_line: 5, symbol: "Display", dependency_type: TypeReference, context: Some("TypeIdentifier:9:28") },
         Dependency { source_line: 10, target_line: 19, symbol: "clone", dependency_type: StructFieldAccess, context: Some("FieldExpression:10:18") },
         Dependency { source_line: 10, target_line: 9, symbol: "item", dependency_type: VariableUse, context: Some("Identifier:10:18") },
@@ -259,6 +258,7 @@ IntermediateRepresentation {
         Usage { position: { 2:24 to 2:28 }, name: "Self", kind: TypeIdentifier, context: None },
         Usage { position: { 6:8 to 6:15 }, name: "display", kind: Identifier, context: None },
         Usage { position: { 6:26 to 6:32 }, name: "String", kind: TypeIdentifier, context: None },
+        Usage { position: { 9:17 to 9:18 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 9:20 to 9:25 }, name: "Clone", kind: TypeIdentifier, context: None },
         Usage { position: { 9:28 to 9:35 }, name: "Display", kind: TypeIdentifier, context: None },
         Usage { position: { 9:44 to 9:45 }, name: "T", kind: TypeIdentifier, context: None },

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_async_dependencies_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_async_dependencies_ir.snap
@@ -113,8 +113,8 @@ AST:
   (function_item
     name: (identifier "spawn_task")
     type_parameters: (type_parameters
-      (constrained_type_parameter
-        left: (type_identifier "F")
+      (type_parameter
+        name: (type_identifier "F")
         bounds: (trait_bounds
           (generic_type
             type: (type_identifier "Future")
@@ -223,7 +223,6 @@ IntermediateRepresentation {
     dependencies: [
         Dependency { source_line: 8, target_line: 3, symbol: "fetch_data", dependency_type: FunctionCall, context: Some("CallExpression:8:16") },
         Dependency { source_line: 9, target_line: 8, symbol: "data", dependency_type: VariableUse, context: Some("Identifier:9:31") },
-        Dependency { source_line: 13, target_line: 1, symbol: "Future", dependency_type: TypeReference, context: Some("TypeIdentifier:13:18") },
         Dependency { source_line: 15, target_line: 13, symbol: "future", dependency_type: VariableUse, context: Some("Identifier:15:26") },
         Dependency { source_line: 19, target_line: 7, symbol: "process_data", dependency_type: FunctionCall, context: Some("CallExpression:19:13") },
         Dependency { source_line: 21, target_line: 13, symbol: "spawn_task", dependency_type: FunctionCall, context: Some("CallExpression:21:5") },
@@ -246,6 +245,7 @@ IntermediateRepresentation {
         Usage { position: { 9:5 to 9:12 }, name: "println", kind: Identifier, context: None },
         Usage { position: { 9:31 to 9:35 }, name: "data", kind: Identifier, context: None },
         Usage { position: { 10:5 to 10:11 }, name: "Ok", kind: CallExpression, context: Some("call_expression") },
+        Usage { position: { 13:15 to 13:16 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 13:18 to 13:24 }, name: "Future", kind: TypeIdentifier, context: None },
         Usage { position: { 13:25 to 13:31 }, name: "Output", kind: TypeIdentifier, context: None },
         Usage { position: { 13:47 to 13:48 }, name: "F", kind: TypeIdentifier, context: None },

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_complex_trait_hierarchy_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_complex_trait_hierarchy_ir.snap
@@ -183,8 +183,8 @@ AST:
   (function_item
     name: (identifier "print_mammal_info")
     type_parameters: (type_parameters
-      (constrained_type_parameter
-        left: (type_identifier "T")
+      (type_parameter
+        name: (type_identifier "T")
         bounds: (trait_bounds
           (type_identifier "Mammal")
         )
@@ -328,6 +328,7 @@ IntermediateRepresentation {
         Usage { position: { 25:6 to 25:12 }, name: "Mammal", kind: TypeIdentifier, context: None },
         Usage { position: { 25:17 to 25:20 }, name: "Dog", kind: TypeIdentifier, context: None },
         Usage { position: { 27:10 to 27:18 }, name: "fur", kind: FieldExpression, context: Some("field_expression") },
+        Usage { position: { 31:22 to 31:23 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 31:25 to 31:31 }, name: "Mammal", kind: TypeIdentifier, context: None },
         Usage { position: { 31:42 to 31:43 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 32:5 to 32:12 }, name: "println", kind: Identifier, context: None },

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_generic_resolution_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_generic_resolution_ir.snap
@@ -32,7 +32,9 @@ AST:
   (struct_item
     name: (type_identifier "Container")
     type_parameters: (type_parameters
-      (type_identifier "T")
+      (type_parameter
+        name: (type_identifier "T")
+      )
     )
     body: (field_declaration_list
       (field_declaration
@@ -43,7 +45,9 @@ AST:
   )
   (impl_item
     type_parameters: (type_parameters
-      (type_identifier "T")
+      (type_parameter
+        name: (type_identifier "T")
+      )
     )
     type: (generic_type
       type: (type_identifier "Container")
@@ -96,8 +100,8 @@ AST:
   (function_item
     name: (identifier "process")
     type_parameters: (type_parameters
-      (constrained_type_parameter
-        left: (type_identifier "T")
+      (type_parameter
+        name: (type_identifier "T")
         bounds: (trait_bounds
           (type_identifier "Clone")
         )
@@ -195,13 +199,14 @@ IntermediateRepresentation {
     ],
     dependencies: [
         Dependency { source_line: 2, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:2:11") },
-        Dependency { source_line: 5, target_line: 1, symbol: "Container", dependency_type: TypeReference, context: Some("TypeIdentifier:5:9") },
+        Dependency { source_line: 5, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:5:6") },
         Dependency { source_line: 5, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:5:19") },
         Dependency { source_line: 6, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:6:18") },
         Dependency { source_line: 7, target_line: 1, symbol: "Container", dependency_type: TypeReference, context: Some("TypeIdentifier:7:9") },
         Dependency { source_line: 7, target_line: 6, symbol: "item", dependency_type: VariableUse, context: Some("Identifier:7:21") },
         Dependency { source_line: 10, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:10:23") },
         Dependency { source_line: 11, target_line: 2, symbol: "item", dependency_type: StructFieldAccess, context: Some("FieldExpression:11:10") },
+        Dependency { source_line: 15, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:15:12") },
         Dependency { source_line: 15, target_line: 1, symbol: "Container", dependency_type: TypeReference, context: Some("TypeIdentifier:15:34") },
         Dependency { source_line: 15, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:15:44") },
         Dependency { source_line: 15, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:15:51") },
@@ -214,7 +219,9 @@ IntermediateRepresentation {
         Dependency { source_line: 22, target_line: 21, symbol: "value", dependency_type: VariableUse, context: Some("Identifier:22:20") },
     ],
     usage: [
+        Usage { position: { 1:18 to 1:19 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 2:11 to 2:12 }, name: "T", kind: TypeIdentifier, context: None },
+        Usage { position: { 5:6 to 5:7 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 5:9 to 5:18 }, name: "Container", kind: TypeIdentifier, context: None },
         Usage { position: { 5:19 to 5:20 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 6:18 to 6:19 }, name: "T", kind: TypeIdentifier, context: None },
@@ -224,6 +231,7 @@ IntermediateRepresentation {
         Usage { position: { 7:21 to 7:25 }, name: "item", kind: Identifier, context: None },
         Usage { position: { 10:23 to 10:24 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 11:10 to 11:19 }, name: "item", kind: FieldExpression, context: Some("field_expression") },
+        Usage { position: { 15:12 to 15:13 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 15:15 to 15:20 }, name: "Clone", kind: TypeIdentifier, context: None },
         Usage { position: { 15:34 to 15:43 }, name: "Container", kind: TypeIdentifier, context: None },
         Usage { position: { 15:44 to 15:45 }, name: "T", kind: TypeIdentifier, context: None },

--- a/crates/core/tests/unit/languages/rust/dependency_resolver/impl_collector_tests.rs
+++ b/crates/core/tests/unit/languages/rust/dependency_resolver/impl_collector_tests.rs
@@ -4,7 +4,7 @@ use tree_sitter::Parser;
 fn setup_rust_parser() -> Parser {
     let mut parser = Parser::new();
     parser
-        .set_language(&tree_sitter_rust::language())
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
         .expect("Error loading Rust grammar");
     parser
 }

--- a/crates/core/tests/unit/languages/rust/dependency_resolver/method_resolver_tests.rs
+++ b/crates/core/tests/unit/languages/rust/dependency_resolver/method_resolver_tests.rs
@@ -17,7 +17,7 @@ fn create_test_position(line: usize) -> Position {
 fn setup_rust_parser() -> Parser {
     let mut parser = Parser::new();
     parser
-        .set_language(&tree_sitter_rust::language())
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
         .expect("Error loading Rust grammar");
     parser
 }

--- a/crates/core/tests/unit/languages/rust/dependency_resolver/nested_scope_resolver_tests.rs
+++ b/crates/core/tests/unit/languages/rust/dependency_resolver/nested_scope_resolver_tests.rs
@@ -67,7 +67,7 @@ fn create_test_scope_tree() -> ScopeTree {
 fn setup_rust_parser() -> Parser {
     let mut parser = Parser::new();
     parser
-        .set_language(&tree_sitter_rust::language())
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
         .expect("Error loading Rust grammar");
     parser
 }

--- a/crates/core/tests/unit/models/position_tests.rs
+++ b/crates/core/tests/unit/models/position_tests.rs
@@ -4,7 +4,7 @@ use tree_sitter::Parser;
 fn setup_rust_parser() -> Parser {
     let mut parser = Parser::new();
     parser
-        .set_language(&tree_sitter_rust::language())
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
         .expect("Error loading Rust grammar");
     parser
 }

--- a/crates/core/tests/unit/models/usage_tests.rs
+++ b/crates/core/tests/unit/models/usage_tests.rs
@@ -4,7 +4,7 @@ use tree_sitter::Parser;
 fn setup_rust_parser() -> Parser {
     let mut parser = Parser::new();
     parser
-        .set_language(&tree_sitter_rust::language())
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
         .expect("Error loading Rust grammar");
     parser
 }

--- a/crates/test-generator/tests/snapshots/rust/test_generated_bounded_type.snap
+++ b/crates/test-generator/tests/snapshots/rust/test_generated_bounded_type.snap
@@ -10,8 +10,8 @@ AST:
   (function_item
     name: (identifier "test")
     type_parameters: (type_parameters
-      (constrained_type_parameter
-        left: (type_identifier "T")
+      (type_parameter
+        name: (type_identifier "T")
         bounds: (trait_bounds
           (type_identifier "Clone")
           (type_identifier "Send")
@@ -55,6 +55,7 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
+        Usage { position: { 1:9 to 1:10 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 1:12 to 1:17 }, name: "Clone", kind: TypeIdentifier, context: None },
         Usage { position: { 1:20 to 1:24 }, name: "Send", kind: TypeIdentifier, context: None },
         Usage { position: { 1:29 to 1:30 }, name: "T", kind: TypeIdentifier, context: None },

--- a/crates/test-generator/tests/snapshots/rust/test_generated_higher_ranked_trait_bound.snap
+++ b/crates/test-generator/tests/snapshots/rust/test_generated_higher_ranked_trait_bound.snap
@@ -10,7 +10,9 @@ AST:
   (function_item
     name: (identifier "test_fn5")
     type_parameters: (type_parameters
-      (type_identifier "F")
+      (type_parameter
+        name: (type_identifier "F")
+      )
     )
     parameters: (parameters
       (parameter
@@ -24,8 +26,10 @@ AST:
         bounds: (trait_bounds
           (higher_ranked_trait_bound
             type_parameters: (type_parameters
-              (lifetime
-                (identifier "a")
+              (lifetime_parameter
+                name: (lifetime
+                  (identifier "a")
+                )
               )
             )
             type: (function_type
@@ -63,6 +67,7 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
+        Usage { position: { 1:13 to 1:14 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 1:19 to 1:20 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 1:28 to 1:29 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 1:39 to 1:41 }, name: "Fn", kind: TypeIdentifier, context: None },

--- a/crates/test-generator/tests/snapshots/rust/test_generated_range_pattern.snap
+++ b/crates/test-generator/tests/snapshots/rust/test_generated_range_pattern.snap
@@ -14,8 +14,8 @@ AST:
         (match_arm
           pattern: (match_pattern
             (range_pattern
-              (integer_literal "0")
-              (integer_literal "10")
+              left: (integer_literal "0")
+              right: (integer_literal "10")
             )
           )
           value: (block)

--- a/crates/test-generator/tests/snapshots/rust/test_generated_removed_trait_bound.snap
+++ b/crates/test-generator/tests/snapshots/rust/test_generated_removed_trait_bound.snap
@@ -10,7 +10,9 @@ AST:
   (function_item
     name: (identifier "test_fn9")
     type_parameters: (type_parameters
-      (type_identifier "T")
+      (type_parameter
+        name: (type_identifier "T")
+      )
     )
     parameters: (parameters
       (parameter
@@ -30,6 +32,7 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
+        Usage { position: { 1:13 to 1:14 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 1:19 to 1:20 }, name: "T", kind: TypeIdentifier, context: None },
     ],
     analysis_metadata: AnalysisMetadata {

--- a/crates/test-generator/tests/snapshots/ts/test_generated_break_statement.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_break_statement.snap
@@ -14,11 +14,9 @@ AST:
         value: (number "0")
       )
     )
-    condition: (expression_statement
-      (binary_expression
-        left: (identifier "i")
-        right: (number "10")
-      )
+    condition: (binary_expression
+      left: (identifier "i")
+      right: (number "10")
     )
     increment: (update_expression
       argument: (identifier "i")

--- a/crates/test-generator/tests/snapshots/ts/test_generated_continue_statement.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_continue_statement.snap
@@ -14,11 +14,9 @@ AST:
         value: (number "0")
       )
     )
-    condition: (expression_statement
-      (binary_expression
-        left: (identifier "i")
-        right: (number "10")
-      )
+    condition: (binary_expression
+      left: (identifier "i")
+      right: (number "10")
     )
     increment: (update_expression
       argument: (identifier "i")

--- a/crates/test-generator/tests/snapshots/ts/test_generated_for_statement.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_for_statement.snap
@@ -14,13 +14,11 @@ AST:
         value: (number "0")
       )
     )
-    condition: (expression_statement
-      (binary_expression
-        left: (identifier "i1")
-        right: (member_expression
-          object: (identifier "arr1")
-          property: (property_identifier "length")
-        )
+    condition: (binary_expression
+      left: (identifier "i1")
+      right: (member_expression
+        object: (identifier "arr1")
+        property: (property_identifier "length")
       )
     )
     increment: (update_expression

--- a/crates/test-generator/tests/snapshots/ts/test_generated_labeled_statement.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_labeled_statement.snap
@@ -16,11 +16,9 @@ AST:
           value: (number "0")
         )
       )
-      condition: (expression_statement
-        (binary_expression
-          left: (identifier "i")
-          right: (number "10")
-        )
+      condition: (binary_expression
+        left: (identifier "i")
+        right: (number "10")
       )
       increment: (update_expression
         argument: (identifier "i")

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_break_statement.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_break_statement.snap
@@ -14,11 +14,9 @@ AST:
         value: (number "0")
       )
     )
-    condition: (expression_statement
-      (binary_expression
-        left: (identifier "i")
-        right: (number "10")
-      )
+    condition: (binary_expression
+      left: (identifier "i")
+      right: (number "10")
     )
     increment: (update_expression
       argument: (identifier "i")

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_continue_statement.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_continue_statement.snap
@@ -14,11 +14,9 @@ AST:
         value: (number "0")
       )
     )
-    condition: (expression_statement
-      (binary_expression
-        left: (identifier "i")
-        right: (number "10")
-      )
+    condition: (binary_expression
+      left: (identifier "i")
+      right: (number "10")
     )
     increment: (update_expression
       argument: (identifier "i")

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_for_statement.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_for_statement.snap
@@ -14,13 +14,11 @@ AST:
         value: (number "0")
       )
     )
-    condition: (expression_statement
-      (binary_expression
-        left: (identifier "i1")
-        right: (member_expression
-          object: (identifier "arr1")
-          property: (property_identifier "length")
-        )
+    condition: (binary_expression
+      left: (identifier "i1")
+      right: (member_expression
+        object: (identifier "arr1")
+        property: (property_identifier "length")
       )
     )
     increment: (update_expression

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_labeled_statement.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_labeled_statement.snap
@@ -16,11 +16,9 @@ AST:
           value: (number "0")
         )
       )
-      condition: (expression_statement
-        (binary_expression
-          left: (identifier "i")
-          right: (number "10")
-        )
+      condition: (binary_expression
+        left: (identifier "i")
+        right: (number "10")
       )
       increment: (update_expression
         argument: (identifier "i")


### PR DESCRIPTION
## Summary
Coordinated upgrade of the three tree-sitter crates that Dependabot could not land individually. Supersedes #141, #144, #152.

| crate                      | from   | to     |
| -------------------------- | ------ | ------ |
| tree-sitter                | 0.22.6 | 0.25.10 |
| tree-sitter-rust           | 0.21.2 | 0.24.2  |
| tree-sitter-typescript     | 0.21.1 | 0.23.2  |
| streaming-iterator (new)   | —      | 0.1     |

### API changes applied
- `tree_sitter_rust::language()` → `tree_sitter_rust::LANGUAGE.into()` (and the two TypeScript variants). Updated at each call site in `crates/core/src/models/language.rs`, `crates/core/src/languages/rust/dependency_resolver/impl_collector.rs`, and 5 unit-test files.
- `QueryCursor::matches` now returns a `StreamingIterator`. `impl_collector` uses `while let Some(m) = matches.next()` and passes the `&QueryMatch` directly (`parse_impl_block` / `parse_trait_impl` / `parse_trait_def` signatures needed no change).

### Snapshot updates (grammar-driven, reviewed and accepted)
- tree-sitter-rust 0.24 wraps generic parameters in a `type_parameter` node, so 4 core integration snapshots and 4 test-generator Rust snapshots pick up the parameter binding sites (e.g. `impl<T>`'s `T` now shows as a TypeReference).
- tree-sitter-typescript 0.23 adds a `body` field around single-statement loops (`for`/`break`/`continue`/`labeled_statement`), refreshing 8 test-generator TS/TSX snapshots.

Once landed, please close #141, #144, and #152.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace --locked` (all ~750 tests pass)
- [x] `cargo audit` (0 vulnerabilities, 3 pre-existing unmaintained warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with updated Rust and TypeScript parsing grammars.
  * Enhanced parsing reliability for Rust implementations, traits, and nested scopes.

* **Tests**
  * Updated parser test coverage to use the latest grammar interfaces.
  * Verified Rust parsing, dependency resolution, position tracking, and usage analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->