### PR TITLE
feat(accuracy): add dependency detection accuracy harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,28 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --locked
 
+  accuracy:
+    name: Dependency detection accuracy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      - name: Report accuracy against the recorded baseline
+        # The test job already gates on the baseline; this job exists to surface the
+        # precision/recall table in the run summary. Differences in either direction fail, so
+        # improvements and regressions both have to be recorded deliberately.
+        run: |
+          cargo run -q -p lintric-accuracy -- --check > accuracy.txt 2>&1 || status=$?
+          {
+            echo '```'
+            cat accuracy.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat accuracy.txt
+          exit "${status:-0}"
+
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,12 @@ If you have a feature request, please open an [issue on GitHub](https://github.c
 
 ### Project Structure
 
-Lintric is organized into two main crates:
+Lintric is organized into the following crates:
 
-*   **`core/`**: Contains the core logic for calculating code metrics based on line-level dependencies. It uses `tree-sitter` for AST parsing and `petgraph` for dependency graph construction.
-*   **`cli/`**: Provides a command-line interface for the Lintric tool, utilizing the `lintric-core` library.
+*   **`crates/core/`**: Contains the core logic for calculating code metrics based on line-level dependencies. It uses `tree-sitter` for AST parsing and `petgraph` for dependency graph construction.
+*   **`crates/cli/`**: Provides a command-line interface for the Lintric tool, utilizing the `lintric-core` library.
+*   **`crates/test-generator/`**: Generates per-node-type analysis tests from tree-sitter node type definitions.
+*   **`crates/accuracy/`**: Measures how accurately dependencies are detected, against hand-written expectations. See [crates/accuracy/README.md](crates/accuracy/README.md).
 
 ## Testing and Quality
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "lintric-accuracy"
+version = "0.1.0"
+dependencies = [
+ "comfy-table",
+ "lintric-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lintric-cli"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/core", "crates/cli", "crates/test-generator"]
+members = ["crates/core", "crates/cli", "crates/test-generator", "crates/accuracy"]
 
 [package]
 name = "lintric-workspace"

--- a/crates/accuracy/Cargo.toml
+++ b/crates/accuracy/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "lintric-accuracy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lintric-core = { path = "../core" }
+comfy-table = "7.2.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[[bin]]
+name = "accuracy"
+path = "src/bin/accuracy.rs"
+
+[[test]]
+name = "baseline"
+path = "tests/baseline.rs"
+
+[[test]]
+name = "unit"
+path = "tests/unit/mod.rs"

--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -1,0 +1,107 @@
+# Lintric Accuracy
+
+Measures how accurately Lintric detects line-level dependencies, and records the result as a
+baseline so that changes in detection behaviour are visible in diffs.
+
+## Why this exists
+
+The rest of the test suite cannot answer "how accurate are we?". Snapshot tests record whatever
+the analyzer currently outputs, so wrong output is locked in as faithfully as right output. The
+generated tests in `crates/test-generator` assert that a node kind analyzes without panicking,
+which is a useful crash net but silent about correctness.
+
+This crate takes the opposite approach: expectations are written by hand from the language's
+semantics, **independent of what the analyzer currently produces**. That makes it possible to
+report precision and recall rather than merely detecting change.
+
+## Running it
+
+```bash
+cargo run -p lintric-accuracy              # print the report
+cargo run -p lintric-accuracy -- --check   # exit non-zero if it differs from the baseline
+cargo run -p lintric-accuracy -- --update  # record the current numbers as the baseline
+```
+
+`cargo test -p lintric-accuracy` gates the same comparison, so a change in detection behaviour
+fails the suite until the baseline is deliberately updated.
+
+## Expectation format
+
+Fixtures live under `fixtures/<language>/` and carry their expectations inline:
+
+```rust
+fn main() {
+    let a = 1;
+    let b = a + 2; //~ depends: a@2
+    let c = a + b; //~ depends: a@2, b@3
+}
+```
+
+An annotation is `//~ depends: <symbol>@<line>[, <symbol>@<line>]*` and applies to **the line it
+appears on**. Because the annotation attaches to its own line, an expectation can be placed on
+any line of a multi-line statement.
+
+Rules:
+
+- **Fixtures are annotated exhaustively.** Any detected edge that is not annotated counts as
+  spurious. There is no way to leave an edge unstated but tolerated — that is the point.
+- A malformed annotation is an error, not a skipped line. A typo cannot silently weaken the
+  expected set.
+- An edge is identified by `(source line, target line, symbol)`, so a wrong symbol on the right
+  lines is counted as one missing edge plus one spurious edge.
+- Dependencies on symbols defined outside the fixture (`println`, `Send`, `JSX`) have no target
+  line and therefore produce no edge.
+
+## Reported numbers
+
+| Column | Meaning |
+| --- | --- |
+| Expected | Hand-written edges |
+| Detected | Distinct edges the analyzer reported |
+| Correct | Detected edges that were expected |
+| Missing | Expected edges not detected |
+| Spurious | Detected edges not expected |
+| Duplicates | Edges the analyzer reported more than once |
+| Precision | Correct / Detected |
+| Recall | Correct / Expected |
+
+Duplicates are reported separately rather than folded into precision. The line-to-line
+dependency graph should contain each edge once, so repeated edges are an over-counting defect in
+their own right — see #172 — and keeping them in their own column stops them from being confused
+with false positives.
+
+Precision and recall are derived when reporting rather than stored, so `baseline.json` holds
+only integer counts and does not churn on float formatting.
+
+## Interpreting the baseline
+
+The current numbers describe **these fixtures only**. They are small, focused files, and the
+recall figure should not be read as an overall accuracy claim for the analyzer — real code fares
+considerably worse. `crates/cli/src/logger.rs`, for instance, yields 2 dependencies for 24 lines
+because every method body is a single `println!("{message}")`.
+
+Growing the fixture set will most likely push the recorded numbers *down*, and that is the
+intended direction: it means the harness is measuring more of what the analyzer actually has to
+handle.
+
+## Deliberately unsettled
+
+Import and cross-scope resolution is not covered yet, because the expected shape is a design
+question rather than a fact about the language. Given
+
+```rust
+mod geometry {
+    pub struct Rect { pub width: i32 }
+}
+use geometry::Rect;
+
+fn main() {
+    let r = Rect { width: 1 };
+}
+```
+
+it is unclear whether `Rect` in `main` should depend on the `use` line (treating the import as
+the local binding) or directly on the struct definition. #87 proposes that import-like
+dependencies be placed at the top scope level, which implies the former, but this has not been
+decided. Fixtures for modules and imports should be added once it is, so that the baseline does
+not encode an accidental answer.

--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -1,0 +1,100 @@
+{
+  "fixtures": {
+    "rust/closures.rs": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "rust/enums.rs": {
+      "expected": 13,
+      "detected": 8,
+      "correct": 8,
+      "missing": 5,
+      "spurious": 0,
+      "duplicates": 3
+    },
+    "rust/functions.rs": {
+      "expected": 8,
+      "detected": 8,
+      "correct": 8,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
+    "rust/macros.rs": {
+      "expected": 8,
+      "detected": 5,
+      "correct": 5,
+      "missing": 3,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "rust/structs.rs": {
+      "expected": 11,
+      "detected": 9,
+      "correct": 9,
+      "missing": 2,
+      "spurious": 0,
+      "duplicates": 2
+    },
+    "rust/traits.rs": {
+      "expected": 12,
+      "detected": 9,
+      "correct": 9,
+      "missing": 3,
+      "spurious": 0,
+      "duplicates": 1
+    },
+    "rust/variables.rs": {
+      "expected": 7,
+      "detected": 7,
+      "correct": 7,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "tsx/component.tsx": {
+      "expected": 2,
+      "detected": 2,
+      "correct": 2,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "typescript/classes.ts": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 2
+    },
+    "typescript/functions.ts": {
+      "expected": 7,
+      "detected": 7,
+      "correct": 7,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
+    "typescript/variables.ts": {
+      "expected": 5,
+      "detected": 5,
+      "correct": 5,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    }
+  },
+  "total": {
+    "expected": 91,
+    "detected": 78,
+    "correct": 78,
+    "missing": 13,
+    "spurious": 0,
+    "duplicates": 10
+  }
+}

--- a/crates/accuracy/fixtures/rust/closures.rs
+++ b/crates/accuracy/fixtures/rust/closures.rs
@@ -1,0 +1,14 @@
+// Closures capturing bindings from the enclosing scope.
+
+fn main() {
+    let base = 10;
+    let add = |n: i32| {
+        n + base //~ depends: n@5, base@4
+    };
+    let result = add(5); //~ depends: add@5
+    let nested = |n: i32| {
+        add(n) + base //~ depends: add@5, n@9, base@4
+    };
+    let total = result + nested(1); //~ depends: result@8, nested@9
+    let _ = total; //~ depends: total@12
+}

--- a/crates/accuracy/fixtures/rust/enums.rs
+++ b/crates/accuracy/fixtures/rust/enums.rs
@@ -1,0 +1,19 @@
+// Enum definitions, variants and match arms.
+
+enum Direction {
+    Left,
+    Right,
+}
+
+fn flip(direction: Direction) -> Direction { //~ depends: Direction@3
+    match direction { //~ depends: direction@8
+        Direction::Left => Direction::Right, //~ depends: Direction@3, Left@4, Right@5
+        Direction::Right => Direction::Left, //~ depends: Direction@3, Right@5, Left@4
+    }
+}
+
+fn main() {
+    let start = Direction::Left; //~ depends: Direction@3, Left@4
+    let end = flip(start); //~ depends: flip@8, start@16
+    let _ = end; //~ depends: end@17
+}

--- a/crates/accuracy/fixtures/rust/functions.rs
+++ b/crates/accuracy/fixtures/rust/functions.rs
@@ -1,0 +1,16 @@
+// Function definitions, parameters and nested calls.
+
+fn double(n: i32) -> i32 {
+    n * 2 //~ depends: n@3
+}
+
+fn quadruple(n: i32) -> i32 {
+    double(double(n)) //~ depends: double@3, n@7
+}
+
+fn main() {
+    let x = 3;
+    let y = quadruple(x); //~ depends: quadruple@7, x@12
+    let z = double(y); //~ depends: double@3, y@13
+    let _ = z; //~ depends: z@14
+}

--- a/crates/accuracy/fixtures/rust/macros.rs
+++ b/crates/accuracy/fixtures/rust/macros.rs
@@ -1,0 +1,11 @@
+// Macro invocations, including inline format string captures.
+
+fn main() {
+    let name = "lintric";
+    let count = 3;
+    let msg = format!("{name} x{count}"); //~ depends: name@4, count@5
+    println!("{msg}"); //~ depends: msg@6
+    println!("{} {}", name, count); //~ depends: name@4, count@5
+    let items = vec![name, msg.as_str()]; //~ depends: name@4, msg@6
+    assert_eq!(items.len(), 2); //~ depends: items@9
+}

--- a/crates/accuracy/fixtures/rust/structs.rs
+++ b/crates/accuracy/fixtures/rust/structs.rs
@@ -1,0 +1,20 @@
+// Struct definitions, field access and struct literals.
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+impl Point { //~ depends: Point@3
+    fn norm(&self) -> i32 {
+        self.x * self.x + self.y * self.y //~ depends: x@4, y@5
+    }
+}
+
+fn main() {
+    let a = 1;
+    let b = 2;
+    let p = Point { x: a, y: b }; //~ depends: Point@3, x@4, y@5, a@15, b@16
+    let n = p.norm(); //~ depends: norm@9, p@17
+    let _ = n; //~ depends: n@18
+}

--- a/crates/accuracy/fixtures/rust/traits.rs
+++ b/crates/accuracy/fixtures/rust/traits.rs
@@ -1,0 +1,26 @@
+// Trait declarations and their implementations.
+
+trait Shape {
+    fn area(&self) -> i32;
+    fn scaled(&self, factor: i32) -> i32;
+}
+
+struct Square {
+    side: i32,
+}
+
+impl Shape for Square { //~ depends: Shape@3, Square@8
+    fn area(&self) -> i32 { //~ depends: area@4
+        self.side * self.side //~ depends: side@9
+    }
+
+    fn scaled(&self, factor: i32) -> i32 { //~ depends: scaled@5
+        self.area() * factor //~ depends: area@13, factor@17
+    }
+}
+
+fn main() {
+    let s = Square { side: 4 }; //~ depends: Square@8, side@9
+    let a = s.scaled(2); //~ depends: scaled@17, s@23
+    let _ = a; //~ depends: a@24
+}

--- a/crates/accuracy/fixtures/rust/variables.rs
+++ b/crates/accuracy/fixtures/rust/variables.rs
@@ -1,0 +1,11 @@
+// Let bindings, arithmetic and shadowing.
+
+fn main() {
+    let a = 1;
+    let b = a + 2; //~ depends: a@4
+    let c = a + b; //~ depends: a@4, b@5
+    let d = c; //~ depends: c@6
+    let a = d + 1; //~ depends: d@7
+    let e = a; //~ depends: a@8
+    let _ = e; //~ depends: e@9
+}

--- a/crates/accuracy/fixtures/tsx/component.tsx
+++ b/crates/accuracy/fixtures/tsx/component.tsx
@@ -1,0 +1,11 @@
+// JSX element and component references.
+
+const title = "lintric";
+
+function Label(): JSX.Element {
+    return <span>{title}</span>; //~ depends: title@3
+}
+
+function App(): JSX.Element {
+    return <Label />; //~ depends: Label@5
+}

--- a/crates/accuracy/fixtures/typescript/classes.ts
+++ b/crates/accuracy/fixtures/typescript/classes.ts
@@ -1,0 +1,18 @@
+// Class fields, constructor parameters and methods.
+
+class Point {
+    x: number;
+    y: number;
+
+    constructor(x: number, y: number) {
+        this.x = x; //~ depends: x@4, x@7
+        this.y = y; //~ depends: y@5, y@7
+    }
+
+    norm(): number {
+        return this.x * this.x + this.y * this.y; //~ depends: x@4, y@5
+    }
+}
+
+const p = new Point(1, 2); //~ depends: Point@3
+const n = p.norm(); //~ depends: norm@12, p@17

--- a/crates/accuracy/fixtures/typescript/functions.ts
+++ b/crates/accuracy/fixtures/typescript/functions.ts
@@ -1,0 +1,13 @@
+// Function declarations, parameters and nested calls.
+
+function double(n: number): number {
+    return n * 2; //~ depends: n@3
+}
+
+function quadruple(n: number): number {
+    return double(double(n)); //~ depends: double@3, n@7
+}
+
+const x = 3;
+const y = quadruple(x); //~ depends: quadruple@7, x@11
+const z = double(y); //~ depends: double@3, y@12

--- a/crates/accuracy/fixtures/typescript/variables.ts
+++ b/crates/accuracy/fixtures/typescript/variables.ts
@@ -1,0 +1,10 @@
+// Const bindings and arithmetic.
+
+const a = 1;
+const b = a + 2; //~ depends: a@3
+const c = a + b; //~ depends: a@3, b@4
+
+function main(): number {
+    const d = c; //~ depends: c@5
+    return d + 1; //~ depends: d@8
+}

--- a/crates/accuracy/src/analysis.rs
+++ b/crates/accuracy/src/analysis.rs
@@ -1,0 +1,33 @@
+use crate::edge::Edge;
+use lintric_core::models::Dependency;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Dependencies the analyzer reported for a fixture.
+pub struct Detected {
+    /// Distinct edges, which is what the line-to-line dependency graph should contain.
+    pub edges: BTreeSet<Edge>,
+    /// Edges the analyzer emitted more than once. Tracked separately so that over-counting
+    /// stays visible instead of being absorbed into the precision figure.
+    pub duplicates: usize,
+}
+
+/// Run the analyzer over a fixture and collect the dependencies it reports.
+pub fn detect(path: &Path) -> Result<Detected, String> {
+    let ir = lintric_core::get_intermediate_representation(path.to_string_lossy().into_owned())?;
+    let reported: Vec<Edge> = ir.dependencies.iter().map(to_edge).collect();
+    let edges: BTreeSet<Edge> = reported.iter().cloned().collect();
+
+    Ok(Detected {
+        duplicates: reported.len() - edges.len(),
+        edges,
+    })
+}
+
+fn to_edge(dependency: &Dependency) -> Edge {
+    Edge::new(
+        dependency.source_line,
+        dependency.target_line,
+        dependency.symbol.clone(),
+    )
+}

--- a/crates/accuracy/src/baseline.rs
+++ b/crates/accuracy/src/baseline.rs
@@ -1,0 +1,85 @@
+use crate::comparison::Counts;
+use crate::report::Report;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+/// Recorded accuracy numbers, checked into the repository so that any change in detection
+/// behaviour shows up as a reviewable diff.
+///
+/// Only integer counts are stored; precision and recall are derived when reporting, so the
+/// file does not churn on float formatting.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Baseline {
+    pub fixtures: BTreeMap<String, Counts>,
+    pub total: Counts,
+}
+
+impl Baseline {
+    pub fn from_report(report: &Report) -> Self {
+        Self {
+            fixtures: report
+                .fixtures
+                .iter()
+                .map(|fixture| (fixture.name.clone(), fixture.counts.clone()))
+                .collect(),
+            total: report.totals(),
+        }
+    }
+
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let content = fs::read_to_string(path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+
+        serde_json::from_str(&content)
+            .map_err(|error| format!("failed to parse {}: {error}", path.display()))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        let content = serde_json::to_string_pretty(self)
+            .map_err(|error| format!("failed to serialize baseline: {error}"))?;
+
+        fs::write(path, format!("{content}\n"))
+            .map_err(|error| format!("failed to write {}: {error}", path.display()))
+    }
+
+    /// Per-fixture differences against another baseline, as human-readable lines.
+    pub fn diff(&self, other: &Baseline) -> Vec<String> {
+        self.fixture_names(other)
+            .into_iter()
+            .filter_map(|name| self.diff_fixture(other, &name))
+            .collect()
+    }
+
+    fn fixture_names(&self, other: &Baseline) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .fixtures
+            .keys()
+            .chain(other.fixtures.keys())
+            .cloned()
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    fn diff_fixture(&self, other: &Baseline, name: &str) -> Option<String> {
+        let recorded = self.fixtures.get(name);
+        let current = other.fixtures.get(name);
+
+        match (recorded, current) {
+            (Some(recorded), Some(current)) if recorded != current => Some(format!(
+                "{name}\n  recorded: {recorded:?}\n  current:  {current:?}"
+            )),
+            (Some(_), Some(_)) => None,
+            (Some(_), None) => Some(format!(
+                "{name}\n  fixture is in the baseline but was not found"
+            )),
+            (None, Some(current)) => Some(format!(
+                "{name}\n  new fixture, not in the baseline\n  current: {current:?}"
+            )),
+            (None, None) => None,
+        }
+    }
+}

--- a/crates/accuracy/src/bin/accuracy.rs
+++ b/crates/accuracy/src/bin/accuracy.rs
@@ -1,0 +1,68 @@
+use lintric_accuracy::baseline::Baseline;
+use lintric_accuracy::report::Report;
+use lintric_accuracy::{baseline_path, fixtures_dir};
+
+/// Reports dependency detection accuracy against the annotated fixtures.
+///
+/// `accuracy`          print the report
+/// `accuracy --check`  exit non-zero if the numbers differ from the recorded baseline
+/// `accuracy --update` overwrite the recorded baseline with the current numbers
+fn main() -> std::process::ExitCode {
+    match run(std::env::args().nth(1).as_deref()) {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("error: {error}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(mode: Option<&str>) -> Result<std::process::ExitCode, String> {
+    let report = Report::run(&fixtures_dir())?;
+
+    match mode {
+        None => print_report(&report),
+        Some("--check") => return check(&report),
+        Some("--update") => update(&report)?,
+        Some(other) => return Err(format!("unknown option {other:?}")),
+    }
+
+    Ok(std::process::ExitCode::SUCCESS)
+}
+
+fn print_report(report: &Report) {
+    println!("{}", report.to_table());
+
+    let details = report.details();
+    if !details.is_empty() {
+        println!("{details}");
+    }
+}
+
+fn check(report: &Report) -> Result<std::process::ExitCode, String> {
+    let recorded = Baseline::load(&baseline_path())?;
+    let current = Baseline::from_report(report);
+    let differences = recorded.diff(&current);
+
+    print_report(report);
+
+    if differences.is_empty() {
+        println!("accuracy matches the recorded baseline");
+        return Ok(std::process::ExitCode::SUCCESS);
+    }
+
+    println!("accuracy differs from the recorded baseline:\n");
+    differences
+        .iter()
+        .for_each(|difference| println!("{difference}"));
+    println!("\nrun `cargo run -p lintric-accuracy -- --update` to record these numbers");
+
+    Ok(std::process::ExitCode::FAILURE)
+}
+
+fn update(report: &Report) -> Result<(), String> {
+    Baseline::from_report(report).save(&baseline_path())?;
+    print_report(report);
+    println!("baseline updated: {}", baseline_path().display());
+    Ok(())
+}

--- a/crates/accuracy/src/comparison.rs
+++ b/crates/accuracy/src/comparison.rs
@@ -1,0 +1,83 @@
+use crate::analysis::Detected;
+use crate::edge::Edge;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::iter::Sum;
+
+/// Result of comparing one fixture's expectations against analyzer output.
+pub struct FixtureReport {
+    pub name: String,
+    pub counts: Counts,
+    pub missing: Vec<Edge>,
+    pub spurious: Vec<Edge>,
+}
+
+/// Countable outcome of a comparison. These are the numbers recorded in the baseline.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Counts {
+    pub expected: usize,
+    pub detected: usize,
+    pub correct: usize,
+    pub missing: usize,
+    pub spurious: usize,
+    pub duplicates: usize,
+}
+
+/// Compare hand-written expectations against analyzer output.
+///
+/// Fixtures are annotated exhaustively, so any detected edge that is not expected counts as
+/// spurious rather than as unstated-but-acceptable.
+pub fn compare(
+    name: impl Into<String>,
+    expected: &BTreeSet<Edge>,
+    detected: Detected,
+) -> FixtureReport {
+    let missing: Vec<Edge> = expected.difference(&detected.edges).cloned().collect();
+    let spurious: Vec<Edge> = detected.edges.difference(expected).cloned().collect();
+
+    FixtureReport {
+        name: name.into(),
+        counts: Counts {
+            expected: expected.len(),
+            detected: detected.edges.len(),
+            correct: expected.intersection(&detected.edges).count(),
+            missing: missing.len(),
+            spurious: spurious.len(),
+            duplicates: detected.duplicates,
+        },
+        missing,
+        spurious,
+    }
+}
+
+impl Counts {
+    /// Share of detected edges that are real.
+    pub fn precision(&self) -> f64 {
+        ratio(self.correct, self.detected)
+    }
+
+    /// Share of real edges that were detected.
+    pub fn recall(&self) -> f64 {
+        ratio(self.correct, self.expected)
+    }
+}
+
+impl<'a> Sum<&'a Counts> for Counts {
+    fn sum<I: Iterator<Item = &'a Counts>>(iter: I) -> Self {
+        iter.fold(Counts::default(), |total, counts| Counts {
+            expected: total.expected + counts.expected,
+            detected: total.detected + counts.detected,
+            correct: total.correct + counts.correct,
+            missing: total.missing + counts.missing,
+            spurious: total.spurious + counts.spurious,
+            duplicates: total.duplicates + counts.duplicates,
+        })
+    }
+}
+
+fn ratio(numerator: usize, denominator: usize) -> f64 {
+    match denominator {
+        0 => 1.0,
+        _ => numerator as f64 / denominator as f64,
+    }
+}

--- a/crates/accuracy/src/edge.rs
+++ b/crates/accuracy/src/edge.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A single line-to-line dependency, identified by source line, target line and symbol.
+///
+/// This is the unit of comparison between hand-written expectations and analyzer output.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Edge {
+    pub source_line: usize,
+    pub target_line: usize,
+    pub symbol: String,
+}
+
+impl Edge {
+    pub fn new(source_line: usize, target_line: usize, symbol: impl Into<String>) -> Self {
+        Self {
+            source_line,
+            target_line,
+            symbol: symbol.into(),
+        }
+    }
+}
+
+impl fmt::Display for Edge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "L{} -> L{} {:?}",
+            self.source_line, self.target_line, self.symbol
+        )
+    }
+}

--- a/crates/accuracy/src/expectation.rs
+++ b/crates/accuracy/src/expectation.rs
@@ -1,0 +1,83 @@
+use crate::edge::Edge;
+use std::collections::BTreeSet;
+use std::fmt;
+
+/// Marker introducing an expectation annotation in a fixture.
+pub const MARKER: &str = "//~";
+
+const DEPENDS: &str = "depends:";
+
+/// Parse `//~ depends: symbol@line, symbol@line` annotations out of a fixture source.
+///
+/// The annotation applies to the line it appears on, so an expectation can be attached to any
+/// line of a multi-line statement by placing the comment on that line.
+pub fn parse_expectations(source: &str) -> Result<BTreeSet<Edge>, ParseError> {
+    let edges = source
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| annotation_body(line).map(|body| (index + 1, body)))
+        .map(|(source_line, body)| parse_annotation(source_line, body))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(edges.into_iter().flatten().collect())
+}
+
+/// Failure to understand an annotation. Reported rather than ignored, so that a typo in a
+/// fixture cannot silently weaken the expected set.
+#[derive(Debug, PartialEq)]
+pub struct ParseError {
+    pub line: usize,
+    pub message: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "line {}: {}", self.line, self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl ParseError {
+    fn new(line: usize, message: impl Into<String>) -> Self {
+        Self {
+            line,
+            message: message.into(),
+        }
+    }
+}
+
+fn annotation_body(line: &str) -> Option<&str> {
+    line.split_once(MARKER).map(|(_, rest)| rest.trim())
+}
+
+fn parse_annotation(source_line: usize, body: &str) -> Result<Vec<Edge>, ParseError> {
+    let list = body.strip_prefix(DEPENDS).ok_or_else(|| {
+        ParseError::new(
+            source_line,
+            format!("expected {MARKER} {DEPENDS} ..., found {MARKER} {body}"),
+        )
+    })?;
+
+    list.split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| parse_entry(source_line, entry))
+        .collect()
+}
+
+fn parse_entry(source_line: usize, entry: &str) -> Result<Edge, ParseError> {
+    let (symbol, target) = entry.rsplit_once('@').ok_or_else(|| {
+        ParseError::new(
+            source_line,
+            format!("expected symbol@line, found {entry:?}"),
+        )
+    })?;
+
+    let target_line = target
+        .trim()
+        .parse()
+        .map_err(|_| ParseError::new(source_line, format!("{target:?} is not a line number")))?;
+
+    Ok(Edge::new(source_line, target_line, symbol.trim()))
+}

--- a/crates/accuracy/src/fixtures.rs
+++ b/crates/accuracy/src/fixtures.rs
@@ -1,0 +1,47 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+const SUPPORTED_EXTENSIONS: [&str; 3] = ["rs", "ts", "tsx"];
+
+/// Collect every fixture under `root`, in a stable order so reports and baselines are
+/// reproducible.
+pub fn discover(root: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut paths = collect(root)?;
+    paths.sort();
+    Ok(paths)
+}
+
+/// Name a fixture is reported under: its path relative to the fixture root, with forward
+/// slashes so baselines are identical across platforms.
+pub fn fixture_name(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn collect(dir: &Path) -> io::Result<Vec<PathBuf>> {
+    let entries = fs::read_dir(dir)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<io::Result<Vec<_>>>()?;
+
+    let nested = entries
+        .into_iter()
+        .map(|path| match path.is_dir() {
+            true => collect(&path),
+            false => Ok(is_fixture(&path).then_some(path).into_iter().collect()),
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+
+    Ok(nested.into_iter().flatten().collect())
+}
+
+fn is_fixture(path: &Path) -> bool {
+    path.extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|extension| SUPPORTED_EXTENSIONS.contains(&extension))
+}

--- a/crates/accuracy/src/lib.rs
+++ b/crates/accuracy/src/lib.rs
@@ -1,0 +1,30 @@
+//! Measures how accurately Lintric detects line-level dependencies.
+//!
+//! Fixtures under `fixtures/` carry hand-written expectations as `//~ depends:` annotations.
+//! The expectations are written from the language's semantics, independent of what the
+//! analyzer currently produces, so this crate can report precision and recall rather than
+//! merely detecting change.
+
+pub mod analysis;
+pub mod baseline;
+pub mod comparison;
+pub mod edge;
+pub mod expectation;
+pub mod fixtures;
+pub mod report;
+
+use std::path::{Path, PathBuf};
+
+/// Directory holding the annotated fixtures.
+pub fn fixtures_dir() -> PathBuf {
+    manifest_dir().join("fixtures")
+}
+
+/// File holding the recorded accuracy numbers.
+pub fn baseline_path() -> PathBuf {
+    manifest_dir().join("baseline.json")
+}
+
+fn manifest_dir() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}

--- a/crates/accuracy/src/report.rs
+++ b/crates/accuracy/src/report.rs
@@ -1,0 +1,103 @@
+use crate::analysis::detect;
+use crate::comparison::{compare, Counts, FixtureReport};
+use crate::expectation::parse_expectations;
+use crate::fixtures::{discover, fixture_name};
+use comfy_table::{presets::UTF8_FULL, Table};
+use std::fs;
+use std::path::Path;
+
+/// Accuracy of dependency detection across every fixture.
+pub struct Report {
+    pub fixtures: Vec<FixtureReport>,
+}
+
+impl Report {
+    /// Analyze every fixture under `root` and compare against its annotations.
+    pub fn run(root: &Path) -> Result<Self, String> {
+        let paths = discover(root)
+            .map_err(|error| format!("failed to read fixtures in {}: {error}", root.display()))?;
+
+        let fixtures = paths
+            .iter()
+            .map(|path| run_fixture(root, path))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { fixtures })
+    }
+
+    pub fn totals(&self) -> Counts {
+        self.fixtures.iter().map(|fixture| &fixture.counts).sum()
+    }
+
+    /// Per-fixture counts plus an aggregate row.
+    pub fn to_table(&self) -> String {
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
+        table.set_header(vec![
+            "Fixture",
+            "Expected",
+            "Detected",
+            "Correct",
+            "Missing",
+            "Spurious",
+            "Duplicates",
+            "Precision",
+            "Recall",
+        ]);
+
+        self.fixtures.iter().for_each(|fixture| {
+            table.add_row(row(&fixture.name, &fixture.counts));
+        });
+
+        table.add_row(row("TOTAL", &self.totals()));
+        table.to_string()
+    }
+
+    /// The individual missing and spurious edges, for diagnosing where accuracy is lost.
+    pub fn details(&self) -> String {
+        self.fixtures
+            .iter()
+            .filter(|fixture| !fixture.missing.is_empty() || !fixture.spurious.is_empty())
+            .map(fixture_details)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+fn run_fixture(root: &Path, path: &Path) -> Result<FixtureReport, String> {
+    let name = fixture_name(root, path);
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("{name}: failed to read fixture: {error}"))?;
+    let expected = parse_expectations(&source).map_err(|error| format!("{name}: {error}"))?;
+    let detected = detect(path).map_err(|error| format!("{name}: analysis failed: {error}"))?;
+
+    Ok(compare(name, &expected, detected))
+}
+
+fn row(name: &str, counts: &Counts) -> Vec<String> {
+    vec![
+        name.to_string(),
+        counts.expected.to_string(),
+        counts.detected.to_string(),
+        counts.correct.to_string(),
+        counts.missing.to_string(),
+        counts.spurious.to_string(),
+        counts.duplicates.to_string(),
+        format!("{:.3}", counts.precision()),
+        format!("{:.3}", counts.recall()),
+    ]
+}
+
+fn fixture_details(fixture: &FixtureReport) -> String {
+    let missing = edge_lines("missing", &fixture.missing);
+    let spurious = edge_lines("spurious", &fixture.spurious);
+
+    format!("{}\n{missing}{spurious}", fixture.name)
+}
+
+fn edge_lines(label: &str, edges: &[crate::edge::Edge]) -> String {
+    edges
+        .iter()
+        .map(|edge| format!("  {label}: {edge}\n"))
+        .collect()
+}

--- a/crates/accuracy/tests/baseline.rs
+++ b/crates/accuracy/tests/baseline.rs
@@ -1,0 +1,38 @@
+use lintric_accuracy::baseline::Baseline;
+use lintric_accuracy::report::Report;
+use lintric_accuracy::{baseline_path, fixtures_dir};
+
+/// Accuracy must match the recorded baseline exactly, in either direction. An improvement is
+/// as much a reason to update the baseline as a regression is, so that every change in
+/// detection behaviour is visible in a diff.
+#[test]
+fn accuracy_matches_recorded_baseline() {
+    let report = Report::run(&fixtures_dir()).expect("failed to run accuracy report");
+    let recorded = Baseline::load(&baseline_path()).expect("failed to load baseline");
+    let differences = recorded.diff(&Baseline::from_report(&report));
+
+    assert!(
+        differences.is_empty(),
+        "accuracy differs from the recorded baseline:\n\n{}\n\n{}\n\nrun `cargo run -p lintric-accuracy -- --update` to record these numbers",
+        differences.join("\n"),
+        report.to_table()
+    );
+}
+
+/// Every fixture must contribute expectations, otherwise it silently measures nothing.
+#[test]
+fn every_fixture_is_annotated() {
+    let report = Report::run(&fixtures_dir()).expect("failed to run accuracy report");
+
+    let unannotated: Vec<&str> = report
+        .fixtures
+        .iter()
+        .filter(|fixture| fixture.counts.expected == 0)
+        .map(|fixture| fixture.name.as_str())
+        .collect();
+
+    assert!(
+        unannotated.is_empty(),
+        "fixtures without any `//~ depends:` annotation: {unannotated:?}"
+    );
+}

--- a/crates/accuracy/tests/unit/comparison_tests.rs
+++ b/crates/accuracy/tests/unit/comparison_tests.rs
@@ -1,0 +1,114 @@
+use lintric_accuracy::analysis::Detected;
+use lintric_accuracy::comparison::{compare, Counts};
+use lintric_accuracy::edge::Edge;
+use std::collections::BTreeSet;
+
+#[test]
+fn counts_an_exact_match_as_fully_correct() {
+    let report = compare("f", &edges([(2, 1, "a")]), detected([(2, 1, "a")], 0));
+
+    assert_eq!(report.counts.correct, 1);
+    assert_eq!(report.counts.precision(), 1.0);
+    assert_eq!(report.counts.recall(), 1.0);
+}
+
+#[test]
+fn reports_an_expected_edge_the_analyzer_did_not_find_as_missing() {
+    let report = compare(
+        "f",
+        &edges([(2, 1, "a"), (3, 1, "a")]),
+        detected([(2, 1, "a")], 0),
+    );
+
+    assert_eq!(report.missing, vec![Edge::new(3, 1, "a")]);
+    assert_eq!(report.counts.recall(), 0.5);
+    assert_eq!(report.counts.precision(), 1.0);
+}
+
+#[test]
+fn reports_an_unexpected_edge_as_spurious() {
+    let report = compare(
+        "f",
+        &edges([(2, 1, "a")]),
+        detected([(2, 1, "a"), (9, 1, "a")], 0),
+    );
+
+    assert_eq!(report.spurious, vec![Edge::new(9, 1, "a")]);
+    assert_eq!(report.counts.precision(), 0.5);
+    assert_eq!(report.counts.recall(), 1.0);
+}
+
+#[test]
+fn treats_a_wrong_symbol_as_both_missing_and_spurious() {
+    let report = compare("f", &edges([(2, 1, "a")]), detected([(2, 1, "b")], 0));
+
+    assert_eq!(report.counts.missing, 1);
+    assert_eq!(report.counts.spurious, 1);
+    assert_eq!(report.counts.correct, 0);
+}
+
+#[test]
+fn keeps_duplicates_out_of_the_precision_figure() {
+    let report = compare("f", &edges([(2, 1, "a")]), detected([(2, 1, "a")], 3));
+
+    assert_eq!(report.counts.duplicates, 3);
+    assert_eq!(report.counts.precision(), 1.0);
+}
+
+#[test]
+fn treats_an_empty_comparison_as_perfect_rather_than_undefined() {
+    let report = compare("f", &edges([]), detected([], 0));
+
+    assert_eq!(report.counts.precision(), 1.0);
+    assert_eq!(report.counts.recall(), 1.0);
+}
+
+#[test]
+fn sums_counts_across_fixtures() {
+    let counts = [
+        Counts {
+            expected: 2,
+            detected: 1,
+            correct: 1,
+            missing: 1,
+            spurious: 0,
+            duplicates: 1,
+        },
+        Counts {
+            expected: 3,
+            detected: 4,
+            correct: 3,
+            missing: 0,
+            spurious: 1,
+            duplicates: 2,
+        },
+    ];
+
+    let total: Counts = counts.iter().sum();
+
+    assert_eq!(
+        total,
+        Counts {
+            expected: 5,
+            detected: 5,
+            correct: 4,
+            missing: 1,
+            spurious: 1,
+            duplicates: 3
+        }
+    );
+}
+
+fn edges<const N: usize>(entries: [(usize, usize, &str); N]) -> BTreeSet<Edge> {
+    entries
+        .into_iter()
+        .map(|(source, target, symbol)| Edge::new(source, target, symbol))
+        .collect()
+}
+
+fn detected<const N: usize>(entries: [(usize, usize, &str); N], duplicates: usize) -> Detected {
+    Detected {
+        edges: edges(entries),
+        duplicates,
+    }
+}

--- a/crates/accuracy/tests/unit/expectation_tests.rs
+++ b/crates/accuracy/tests/unit/expectation_tests.rs
@@ -1,0 +1,68 @@
+use lintric_accuracy::edge::Edge;
+use lintric_accuracy::expectation::parse_expectations;
+
+#[test]
+fn parses_a_single_expectation_against_the_annotated_line() {
+    let expected = parse_expectations("let a = 1;\nlet b = a; //~ depends: a@1\n").unwrap();
+
+    assert_eq!(expected, [Edge::new(2, 1, "a")].into_iter().collect());
+}
+
+#[test]
+fn parses_several_expectations_on_one_line() {
+    let expected = parse_expectations("//~ depends: a@10, b@11 , c@12").unwrap();
+
+    assert_eq!(
+        expected,
+        [
+            Edge::new(1, 10, "a"),
+            Edge::new(1, 11, "b"),
+            Edge::new(1, 12, "c")
+        ]
+        .into_iter()
+        .collect()
+    );
+}
+
+#[test]
+fn keeps_same_symbol_resolving_to_different_lines_as_distinct_edges() {
+    let expected = parse_expectations("//~ depends: x@2, x@5").unwrap();
+
+    assert_eq!(expected.len(), 2);
+}
+
+#[test]
+fn collapses_an_expectation_repeated_on_one_line() {
+    let expected = parse_expectations("//~ depends: x@2, x@2").unwrap();
+
+    assert_eq!(expected, [Edge::new(1, 2, "x")].into_iter().collect());
+}
+
+#[test]
+fn finds_no_expectations_in_an_unannotated_source() {
+    let expected = parse_expectations("let a = 1;\n// a plain comment\n").unwrap();
+
+    assert!(expected.is_empty());
+}
+
+#[test]
+fn rejects_an_unknown_directive_rather_than_ignoring_it() {
+    let error = parse_expectations("let a = 1; //~ dependss: a@1").unwrap_err();
+
+    assert_eq!(error.line, 1);
+    assert!(error.message.contains("depends:"), "{}", error.message);
+}
+
+#[test]
+fn rejects_an_entry_without_a_target_line() {
+    let error = parse_expectations("//~ depends: a").unwrap_err();
+
+    assert!(error.message.contains("symbol@line"), "{}", error.message);
+}
+
+#[test]
+fn rejects_a_target_line_that_is_not_a_number() {
+    let error = parse_expectations("//~ depends: a@one").unwrap_err();
+
+    assert!(error.message.contains("line number"), "{}", error.message);
+}

--- a/crates/accuracy/tests/unit/mod.rs
+++ b/crates/accuracy/tests/unit/mod.rs
@@ -1,0 +1,2 @@
+mod comparison_tests;
+mod expectation_tests;

--- a/docs/development/commands.md
+++ b/docs/development/commands.md
@@ -32,6 +32,15 @@
     ```bash
     cargo insta accept --workspace
     ```
+*   **Measure Dependency Detection Accuracy**:
+    Reports precision and recall against hand-written expectations, so a change in what the
+    analyzer detects is visible as a number rather than only as a changed snapshot. See
+    [crates/accuracy/README.md](../../crates/accuracy/README.md) for the annotation format.
+    ```bash
+    cargo run -p lintric-accuracy              # print the report
+    cargo run -p lintric-accuracy -- --check   # compare against the recorded baseline
+    cargo run -p lintric-accuracy -- --update  # record the current numbers
+    ```
 *   **Generate Code Coverage Report**:
     (Requires `cargo-tarpaulin` to be installed: `cargo install cargo-tarpaulin`)
     ```bash


### PR DESCRIPTION
close: #169

## Why

There is currently no way to tell whether Lintric's dependency detection is getting better or worse. The suite is large and green, but it cannot detect an accuracy regression and it cannot say how accurate we are now:

- **Snapshot tests** record whatever the analyzer currently outputs. Wrong output is locked in as faithfully as right output.
- **Generated tests** (574 of 736) assert that a node kind analyzes without panicking. A useful crash net, silent about correctness.

This blocks the planned migration of node extraction to tree-sitter queries (#170): that is a rewrite of the layer producing all dependency data, and without a numeric baseline there is no way to show it preserved behaviour.

## What

A new `crates/accuracy` whose fixtures carry hand-written expectations inline:

```rust
fn main() {
    let a = 1;
    let b = a + 2; //~ depends: a@2
    let c = a + b; //~ depends: a@2, b@3
}
```

Expectations are written from the language's semantics, **independent of what the analyzer currently produces**, which is what makes precision and recall meaningful rather than merely change-detecting.

```bash
cargo run -p lintric-accuracy              # print the report
cargo run -p lintric-accuracy -- --check   # exit non-zero if it differs from the baseline
cargo run -p lintric-accuracy -- --update  # record the current numbers
```

## Design decisions

- **Fixtures are annotated exhaustively.** Any detected edge that is not annotated counts as spurious. There is no way to leave an edge unstated but tolerated — that is the point.
- **An edge is `(source line, target line, symbol)`.** A wrong symbol on the right lines counts as one missing plus one spurious edge.
- **Duplicates get their own column** rather than being folded into precision. The line-to-line graph should hold each edge once, so repeated edges are an over-counting defect (#172) rather than a false positive, and conflating the two would hide both.
- **A malformed annotation is an error, not a skipped line**, so a typo cannot silently weaken the expected set.
- **The baseline is compared exactly in both directions.** An improvement has to be recorded as deliberately as a regression, so every change in detection behaviour lands as a reviewable diff.
- **Only integer counts are stored**; precision and recall are derived when reporting, so `baseline.json` does not churn on float formatting.

## Recorded baseline

11 fixtures, 91 expected edges:

```
TOTAL   expected 91  detected 78  correct 78  missing 13  spurious 0  duplicates 10
        precision 1.000  recall 0.857
```

| Fixture | Recall | What it exposes |
| --- | --- | --- |
| `rust/enums.rs` | 0.615 | #176 |
| `rust/macros.rs` | 0.625 | #171 |
| `rust/traits.rs` | 0.750 | #175, #177 |
| `rust/structs.rs` | 0.818 | #177 |
| 7 others | 1.000 | — |

**Precision is 1.000 on every fixture.** The analyzer is conservative — it under-reports rather than over-reports, and no fixture produced a single spurious edge. The spurious/precision path is therefore covered by unit tests rather than by fixture data.

The recorded recall describes **these fixtures only** and is not an overall accuracy claim. `crates/cli/src/logger.rs` yields 2 dependencies for 24 lines, because every method body is a single `println!("{message}")`. Growing the fixture set will most likely push the number down, which is the intended direction.

## Findings

The harness surfaced two defects that were not previously filed:

- #176 — enum variants are never registered as definitions, and their declaration sites are emitted as usages instead
- #177 — struct literal field names do not depend on field declarations, even though field *access* resolves correctly

It also let #174 be triaged down: composite usages never resolve to a definition, so they cost no precision.

## Deliberately out of scope

Import and cross-scope resolution has no fixtures. Whether `Rect` in `main` should depend on the `use` line or directly on the struct definition is a design question that interacts with #87, not a fact about the language, and guessing would turn an accidental answer into the baseline. Documented under "Deliberately unsettled" in the crate README.

Auditing existing snapshots for known-wrong expected values — the last item on #169's task list — is also not done here.

## Verification

- 17 new tests (15 unit + 2 baseline); full suite 753 passing
- `cargo clippy -p lintric-accuracy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `--check` failure path verified by hand: perturbing one fixture annotation exits 1 with a per-fixture diff

Note: `cargo clippy --workspace --all-targets` reports 26 pre-existing warnings in test files unrelated to this change (`Position` clones, redundant imports, always-true assertions). None are in files touched here. CI runs `cargo clippy --workspace` without `--all-targets`, so they have never been gated. Worth a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dependency-detection accuracy tool with precision, recall, missing, spurious, and duplicate reporting.
  * Added Rust, TypeScript, and TSX test fixtures with inline dependency expectations.
  * Added baseline comparison and update modes for tracking accuracy over time.

* **Documentation**
  * Documented accuracy measurement, annotations, baseline workflows, and project structure.

* **Tests**
  * Added accuracy validation, parser tests, comparison tests, and continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->