### PR TITLE
fix(core): extract identifiers captured by Rust format strings

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -25,10 +25,10 @@
       "duplicates": 1
     },
     "rust/macros.rs": {
-      "expected": 8,
-      "detected": 5,
-      "correct": 5,
-      "missing": 3,
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
       "spurious": 0,
       "duplicates": 0
     },
@@ -90,10 +90,10 @@
     }
   },
   "total": {
-    "expected": 91,
-    "detected": 78,
-    "correct": 78,
-    "missing": 13,
+    "expected": 92,
+    "detected": 82,
+    "correct": 82,
+    "missing": 10,
     "spurious": 0,
     "duplicates": 10
   }

--- a/crates/accuracy/fixtures/rust/macros.rs
+++ b/crates/accuracy/fixtures/rust/macros.rs
@@ -6,6 +6,8 @@ fn main() {
     let msg = format!("{name} x{count}"); //~ depends: name@4, count@5
     println!("{msg}"); //~ depends: msg@6
     println!("{} {}", name, count); //~ depends: name@4, count@5
+    println!("{count:>8}"); //~ depends: count@5
+    println!("{{name}} is escaped");
     let items = vec![name, msg.as_str()]; //~ depends: name@4, msg@6
-    assert_eq!(items.len(), 2); //~ depends: items@9
+    assert_eq!(items.len(), 2); //~ depends: items@11
 }

--- a/crates/core/src/languages/rust/format_string.rs
+++ b/crates/core/src/languages/rust/format_string.rs
@@ -1,0 +1,216 @@
+use crate::models::{Position, ScopeId, Usage, UsageKind};
+use tree_sitter::Node;
+
+/// Macros whose first string argument is a format string.
+const FORMAT_MACROS: [&str; 18] = [
+    "assert",
+    "assert_eq",
+    "assert_ne",
+    "debug_assert",
+    "debug_assert_eq",
+    "debug_assert_ne",
+    "eprint",
+    "eprintln",
+    "format",
+    "format_args",
+    "panic",
+    "print",
+    "println",
+    "todo",
+    "unimplemented",
+    "unreachable",
+    "write",
+    "writeln",
+];
+
+/// Extract the usages a format string captures inline.
+///
+/// Since Rust 2021, `println!("{name}")` refers to `name` directly rather than through the
+/// argument list, so the identifier only exists inside the string literal and is invisible to
+/// AST traversal. `node` is expected to be a `string_content`.
+pub fn capture_usages(node: Node, scope: ScopeId, source: &str) -> Vec<Usage> {
+    match is_format_string(node, source) {
+        false => vec![],
+        true => node
+            .utf8_text(source.as_bytes())
+            .map(|content| usages(&node, scope, content))
+            .unwrap_or_default(),
+    }
+}
+
+/// An identifier a format string captures, as in `"{name}"` or `"{value:>width$}"`.
+struct Capture {
+    name: String,
+    /// Byte offset of the identifier within the format string content.
+    offset: usize,
+}
+
+fn usages(node: &Node, scope: ScopeId, content: &str) -> Vec<Usage> {
+    captures(content)
+        .into_iter()
+        .map(|capture| Usage {
+            position: position(node, content, &capture),
+            name: capture.name,
+            kind: UsageKind::Identifier,
+            context: Some("format_string".to_string()),
+            scope_id: Some(scope),
+        })
+        .collect()
+}
+
+/// Identifiers captured by the placeholders of a format string.
+///
+/// Positional (`"{0}"`) and empty (`"{}"`) placeholders take their value from the argument list,
+/// so they capture nothing.
+fn captures(content: &str) -> Vec<Capture> {
+    placeholders(content)
+        .into_iter()
+        .flat_map(|(offset, body)| placeholder_captures(offset, body))
+        .collect()
+}
+
+/// Byte offset and body of every `{...}` placeholder, skipping `{{` and `}}` escapes.
+fn placeholders(content: &str) -> Vec<(usize, &str)> {
+    let chars: Vec<(usize, char)> = content.char_indices().collect();
+    let mut found = Vec::new();
+    let mut index = 0;
+
+    while index < chars.len() {
+        let pair = (chars[index].1, chars.get(index + 1).map(|(_, c)| *c));
+
+        if matches!(pair, ('{', Some('{')) | ('}', Some('}'))) {
+            index += 2;
+            continue;
+        }
+
+        if pair.0 != '{' {
+            index += 1;
+            continue;
+        }
+
+        match closing_brace(&chars, index) {
+            None => break,
+            Some(close) => {
+                // `{` is single-byte, so the body starts on a character boundary.
+                let start = chars[index].0 + 1;
+                found.push((start, &content[start..chars[close].0]));
+                index = close + 1;
+            }
+        }
+    }
+
+    found
+}
+
+fn closing_brace(chars: &[(usize, char)], open: usize) -> Option<usize> {
+    chars
+        .iter()
+        .enumerate()
+        .skip(open + 1)
+        .find(|(_, (_, character))| *character == '}')
+        .map(|(index, _)| index)
+}
+
+fn placeholder_captures(offset: usize, body: &str) -> Vec<Capture> {
+    let (argument, spec) = match body.split_once(':') {
+        Some((argument, spec)) => (argument, Some(spec)),
+        None => (body, None),
+    };
+
+    let named = identifier(argument).map(|name| Capture { name, offset });
+    let referenced = spec
+        .map(|spec| spec_captures(spec, offset + argument.len() + 1))
+        .unwrap_or_default();
+
+    named.into_iter().chain(referenced).collect()
+}
+
+/// `name$` inside a format spec references a binding for width or precision, as in `"{:w$}"`.
+fn spec_captures(spec: &str, offset: usize) -> Vec<Capture> {
+    spec.match_indices('$')
+        .filter_map(|(end, _)| identifier_ending_at(spec, end))
+        .map(|(start, name)| Capture {
+            name,
+            offset: offset + start,
+        })
+        .collect()
+}
+
+fn identifier_ending_at(spec: &str, end: usize) -> Option<(usize, String)> {
+    let start = spec[..end]
+        .char_indices()
+        .rev()
+        .take_while(|(_, character)| is_identifier_char(*character))
+        .last()
+        .map(|(index, _)| index)?;
+
+    identifier(&spec[start..end]).map(|name| (start, name))
+}
+
+fn identifier(text: &str) -> Option<String> {
+    let text = text.trim();
+    let first = text.chars().next()?;
+
+    (first.is_alphabetic() || first == '_')
+        .then(|| text.to_string())
+        .filter(|text| text.chars().all(is_identifier_char))
+}
+
+fn is_identifier_char(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
+}
+
+fn position(node: &Node, content: &str, capture: &Capture) -> Position {
+    let start = node.start_position();
+    let prefix = &content[..capture.offset];
+    let line = start.row + 1 + prefix.matches('\n').count();
+
+    // Columns are byte offsets within their line, so a capture on the string's first line is
+    // offset from the string's own column and a later line starts from zero.
+    let column = match prefix.rfind('\n') {
+        Some(index) => capture.offset - index - 1,
+        None => start.column + capture.offset,
+    };
+
+    Position {
+        start_line: line,
+        start_column: column + 1,
+        end_line: line,
+        end_column: column + 1 + capture.name.len(),
+    }
+}
+
+fn is_format_string(node: Node, source: &str) -> bool {
+    parent_of_kind(node, "string_literal")
+        .and_then(|literal| parent_of_kind(literal, "token_tree").map(|tokens| (literal, tokens)))
+        .and_then(|(literal, tokens)| {
+            parent_of_kind(tokens, "macro_invocation")
+                .map(|macro_node| (literal, tokens, macro_node))
+        })
+        .is_some_and(|(literal, tokens, macro_node)| {
+            is_format_macro(&macro_node, source) && is_first_string_literal(&tokens, &literal)
+        })
+}
+
+fn parent_of_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    node.parent().filter(|parent| parent.kind() == kind)
+}
+
+fn is_format_macro(macro_node: &Node, source: &str) -> bool {
+    macro_node
+        .child_by_field_name("macro")
+        .and_then(|name| name.utf8_text(source.as_bytes()).ok())
+        .is_some_and(|name| FORMAT_MACROS.contains(&name))
+}
+
+/// Only the first string in the token tree is the format string; later ones are arguments,
+/// so their braces are data rather than placeholders.
+fn is_first_string_literal(tokens: &Node, literal: &Node) -> bool {
+    let mut cursor = tokens.walk();
+
+    let first = tokens
+        .children(&mut cursor)
+        .find(|child| child.kind() == "string_literal");
+
+    first.is_some_and(|first| first.id() == literal.id())
+}

--- a/crates/core/src/languages/rust/mod.rs
+++ b/crates/core/src/languages/rust/mod.rs
@@ -1,3 +1,4 @@
 pub mod dependency_resolver;
+pub mod format_string;
 pub mod formatter;
 pub mod rust_node_extractors;

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -1,5 +1,6 @@
 use tree_sitter::Node;
 
+use super::format_string;
 use crate::models::{
     ast_traverser::{NodeDefinitionExtractor, NodeUsageExtractor},
     Definition, DefinitionType, Position, ScopeId, ScopeType, Usage, UsageKind,
@@ -759,7 +760,7 @@ impl RustDefinitionExtractor {
 pub struct RustUsageExtractor;
 
 impl NodeUsageExtractor for RustUsageExtractor {
-    fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Option<Usage> {
+    fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Usage> {
         let kind = match node.kind() {
             "identifier" => {
                 // Only treat identifier as usage if it's not in a definition context
@@ -787,14 +788,25 @@ impl NodeUsageExtractor for RustUsageExtractor {
             }
             "call_expression" => {
                 // Use special handling for call expressions to extract function name
-                return self.extract_call_usage(node, scope, source);
+                return self
+                    .extract_call_usage(node, scope, source)
+                    .into_iter()
+                    .collect();
             }
             "field_expression" => {
                 // Use special handling for field expressions to extract field name
-                return self.extract_field_usage(node, scope, source);
+                return self
+                    .extract_field_usage(node, scope, source)
+                    .into_iter()
+                    .collect();
             }
             "struct_expression" => Some(UsageKind::StructExpression),
             "metavariable" => Some(UsageKind::Metavariable),
+            "string_content" => {
+                // Inline format string captures have no nodes of their own, so they are parsed
+                // out of the literal rather than reached by traversal
+                return format_string::capture_usages(node, scope, source);
+            }
             _ => None,
         };
 
@@ -808,6 +820,8 @@ impl NodeUsageExtractor for RustUsageExtractor {
                 scope_id: Some(scope),
             })
         })
+        .into_iter()
+        .collect()
     }
 }
 

--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -608,8 +608,8 @@ impl TypeScriptDefinitionExtractor {
 pub struct TypeScriptUsageExtractor;
 
 impl NodeUsageExtractor for TypeScriptUsageExtractor {
-    fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Option<Usage> {
-        match node.kind() {
+    fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Usage> {
+        let usage = match node.kind() {
             "identifier" => {
                 if self.is_usage_context(node) {
                     self.extract_identifier_usage(node, scope, source)
@@ -628,7 +628,9 @@ impl NodeUsageExtractor for TypeScriptUsageExtractor {
             }
             "property_identifier" => self.extract_property_identifier_usage(node, scope, source),
             _ => None,
-        }
+        };
+
+        usage.into_iter().collect()
     }
 }
 

--- a/crates/core/src/models/ast_traverser.rs
+++ b/crates/core/src/models/ast_traverser.rs
@@ -13,8 +13,11 @@ pub trait NodeDefinitionExtractor {
 
 /// Trait for extracting usage information from AST nodes
 pub trait NodeUsageExtractor {
-    /// Extract usage from a node if it represents one
-    fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Option<Usage>;
+    /// Extract usages from a node if it represents any
+    ///
+    /// A single node can carry more than one usage: a format string literal captures an
+    /// identifier per placeholder, and none of them exist as nodes of their own.
+    fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Usage>;
 }
 
 /// Unified AST traverser with scope management
@@ -92,8 +95,9 @@ impl ASTScopeTraverser {
                 .add_definition(definition.name.clone(), definition);
         }
 
-        // Extract usage from this node
-        if let Some(mut usage) = usage_extractor.extract_usage(node, self.current_scope, source) {
+        // Extract usages from this node
+        let usages = usage_extractor.extract_usage(node, self.current_scope, source);
+        for mut usage in usages {
             // Set scope context for the usage
             usage.set_scope_id(Some(self.current_scope));
             context.usages.add_usage(usage);
@@ -142,8 +146,8 @@ mod tests {
     }
 
     impl NodeUsageExtractor for MockUsageExtractor {
-        fn extract_usage(&self, _node: Node, _scope: ScopeId, _source: &str) -> Option<Usage> {
-            None
+        fn extract_usage(&self, _node: Node, _scope: ScopeId, _source: &str) -> Vec<Usage> {
+            vec![]
         }
     }
 

--- a/crates/core/tests/unit/languages/rust/format_string_tests.rs
+++ b/crates/core/tests/unit/languages/rust/format_string_tests.rs
@@ -1,0 +1,167 @@
+use lintric_core::{analyze_content, Language};
+
+#[test]
+fn captures_an_inline_placeholder() {
+    let dependencies =
+        dependencies("fn main() {\n    let name = 1;\n    println!(\"{name}\");\n}\n");
+
+    assert!(
+        dependencies.contains(&(3, 2, "name".to_string())),
+        "{dependencies:?}"
+    );
+}
+
+#[test]
+fn captures_every_placeholder_on_one_line() {
+    let dependencies = dependencies(
+        "fn main() {\n    let a = 1;\n    let b = 2;\n    println!(\"{a} {b}\");\n}\n",
+    );
+
+    assert!(
+        dependencies.contains(&(4, 2, "a".to_string())),
+        "{dependencies:?}"
+    );
+    assert!(
+        dependencies.contains(&(4, 3, "b".to_string())),
+        "{dependencies:?}"
+    );
+}
+
+#[test]
+fn captures_a_placeholder_carrying_a_format_spec() {
+    let dependencies =
+        dependencies("fn main() {\n    let name = 1;\n    println!(\"{name:?}\");\n}\n");
+
+    assert!(
+        dependencies.contains(&(3, 2, "name".to_string())),
+        "{dependencies:?}"
+    );
+}
+
+#[test]
+fn captures_a_binding_referenced_by_a_width_spec() {
+    let dependencies = dependencies(
+        "fn main() {\n    let value = 1;\n    let width = 2;\n    println!(\"{value:>width$}\");\n}\n",
+    );
+
+    assert!(
+        dependencies.contains(&(4, 2, "value".to_string())),
+        "{dependencies:?}"
+    );
+    assert!(
+        dependencies.contains(&(4, 3, "width".to_string())),
+        "{dependencies:?}"
+    );
+}
+
+#[test]
+fn captures_from_a_format_string_that_is_not_the_first_argument() {
+    let dependencies = dependencies(
+        "fn main() {\n    let out = 1;\n    let name = 2;\n    write!(out, \"{name}\");\n}\n",
+    );
+
+    assert!(
+        dependencies.contains(&(4, 3, "name".to_string())),
+        "{dependencies:?}"
+    );
+}
+
+#[test]
+fn ignores_escaped_braces() {
+    let usages = usage_names(
+        "fn main() {\n    let name = 1;\n    println!(\"{{name}}\");\n}\n",
+        3,
+    );
+
+    assert!(!usages.contains(&"name".to_string()), "{usages:?}");
+}
+
+#[test]
+fn ignores_a_positional_placeholder() {
+    let usages = usage_names(
+        "fn main() {\n    let name = 1;\n    println!(\"{0}\", name);\n}\n",
+        3,
+    );
+
+    assert_eq!(
+        usages.iter().filter(|name| *name == "0").count(),
+        0,
+        "{usages:?}"
+    );
+}
+
+#[test]
+fn ignores_an_empty_placeholder() {
+    let usages = usage_names(
+        "fn main() {\n    let name = 1;\n    println!(\"{}\", name);\n}\n",
+        3,
+    );
+
+    assert_eq!(
+        usages.iter().filter(|name| *name == "name").count(),
+        1,
+        "the argument is the only usage: {usages:?}"
+    );
+}
+
+#[test]
+fn ignores_a_string_that_is_not_a_format_string() {
+    let usages = usage_names(
+        "fn main() {\n    let name = 1;\n    my_macro!(\"{name}\");\n}\n",
+        3,
+    );
+
+    assert!(!usages.contains(&"name".to_string()), "{usages:?}");
+}
+
+#[test]
+fn ignores_braces_in_a_later_string_argument() {
+    let usages = usage_names(
+        "fn main() {\n    let name = 1;\n    println!(\"{name}\", \"{other}\");\n}\n",
+        3,
+    );
+
+    assert!(usages.contains(&"name".to_string()), "{usages:?}");
+    assert!(!usages.contains(&"other".to_string()), "{usages:?}");
+}
+
+#[test]
+fn points_a_capture_at_its_identifier_inside_the_string() {
+    let source = "fn main() {\n    let name = 1;\n    println!(\"{name}\");\n}\n";
+    let (ir, _) = analyze_content(source.to_string(), Language::Rust).unwrap();
+
+    let capture = ir
+        .usage
+        .iter()
+        .find(|usage| usage.name == "name" && usage.position.start_line == 3)
+        .expect("capture usage not found");
+
+    // `    println!("{name}");` places the identifier at column 16, 1-based.
+    assert_eq!(capture.position.start_column, 16);
+    assert_eq!(capture.position.end_column, 20);
+}
+
+fn dependencies(source: &str) -> Vec<(usize, usize, String)> {
+    let (ir, _) = analyze_content(source.to_string(), Language::Rust).unwrap();
+
+    ir.dependencies
+        .iter()
+        .map(|dependency| {
+            (
+                dependency.source_line,
+                dependency.target_line,
+                dependency.symbol.clone(),
+            )
+        })
+        .collect()
+}
+
+fn usage_names(source: &str, line: usize) -> Vec<String> {
+    let (ir, _) = analyze_content(source.to_string(), Language::Rust).unwrap();
+
+    ir.usage
+        .iter()
+        .filter(|usage| usage.position.start_line == line)
+        .map(|usage| usage.name.clone())
+        .collect()
+}

--- a/crates/core/tests/unit/languages/rust/mod.rs
+++ b/crates/core/tests/unit/languages/rust/mod.rs
@@ -1,1 +1,2 @@
 pub mod dependency_resolver;
+pub mod format_string_tests;


### PR DESCRIPTION
close: #171

> **Stacked on #178.** Base is `feature/accuracy-measurement-harness` because the accuracy numbers this PR moves live in that branch. GitHub will retarget this to `main` once #178 merges.

## Problem

Since Rust 2021, `println!("{name}")` refers to `name` directly rather than through the argument list. The identifier exists only as text inside the string literal, so AST traversal never reaches it and the dependency was silently absent.

Macro *arguments* were already handled — `format!("{} {}", name, name)` resolved fine. Only the inline capture form was missed, which is the idiomatic one in modern Rust.

This was not an edge case. Every method body in `crates/cli/src/logger.rs` is a single `println!("{message}")` or `eprintln!("{message}")`, which left the whole 24-line file with two dependencies and a complexity score that was effectively noise.

## Approach

Inline captures have no AST nodes of their own, so they cannot be reached by traversal. They are parsed out of the `string_content` node instead, in a new `crates/core/src/languages/rust/format_string.rs`.

This required widening `NodeUsageExtractor::extract_usage` from `Option<Usage>` to `Vec<Usage>`, since one format string yields one usage per placeholder. That mirrors `NodeDefinitionExtractor::extract_definition`, which already returns `Vec<Definition>`. Committed separately, with `TypeScriptUsageExtractor` and the traverser updated mechanically.

Covered:

- `"{name}"` — inline capture
- `"{name:?}"` — capture carrying a format spec
- `"{value:>width$}"` — the width/precision reference is a capture too
- `{{` / `}}` — escapes are not placeholders
- `"{0}"` / `"{}"` — take their value from the argument list, so they capture nothing
- `write!(out, "{name}")` — the format string need not be the first argument
- Only the **first** string literal in the token tree is the format string, so braces in `println!("{name}", "{other}")`'s second string stay data
- All 18 format-like macros (`format`, `print*`, `eprint*`, `write*`, `panic`, `assert*`, `debug_assert*`, `todo`, `unimplemented`, `unreachable`, `format_args`)

## Result

Measured by the accuracy harness (#169):

| | before | after |
| --- | --- | --- |
| `rust/macros.rs` recall | 0.625 | **1.000** |
| overall recall | 0.857 | **0.891** |
| overall precision | 1.000 | 1.000 |
| duplicates | 10 | 10 |

No spurious edges and no new duplicates.

`crates/cli/src/logger.rs` goes from 2 dependencies to 5:

```
L12 -> L3  'Logger'      (TypeReference)
L12 -> L10 'StdIoLogger' (TypeReference)
L14 -> L13 'message'     (VariableUse)   <- new
L18 -> L17 'message'     (VariableUse)   <- new
L22 -> L21 'message'     (VariableUse)   <- new
```

The remaining gap in that file is #175 — impl methods are not linked to their trait declarations.

## Not affected: TypeScript

No TypeScript change was needed. Template literal substitutions are real AST nodes, so `` `hello ${name}` `` already resolves — verified to produce `L2 -> L1 'name'`.

## Verification

- 11 new tests in `crates/core/tests/unit/languages/rust/format_string_tests.rs`, asserted through the public `analyze_content` API. One checks that a capture's reported column points at the identifier inside the string, since that position is computed rather than taken from a node.
- The accuracy fixture gains a spec-carrying placeholder and an escaped-brace line. The escaped line carries **no annotation**, so under the exhaustive-annotation rule a regression in escape handling would surface as a precision drop rather than going unnoticed.
- Full suite 764 passing, no snapshot regressions.
- `cargo clippy -p lintric-core -- -D warnings` and `cargo fmt --all -- --check` clean.

Note: `cargo clippy --workspace --all-targets` reports 26 pre-existing warnings in test files unrelated to this change. None are in files touched here. Worth a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)