### PR TITLE
fix(core): register TypeScript parameter properties as properties

### DIFF
--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -306,20 +306,23 @@ impl TypeScriptDefinitionExtractor {
         scope: ScopeId,
         source: &str,
     ) -> Vec<Definition> {
+        let in_constructor = self.is_constructor_parameter_list(node, source);
         let mut definitions = vec![];
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             match child.kind() {
                 "required_parameter" | "optional_parameter" => {
+                    let definition_type = match in_constructor && self.declares_property(child) {
+                        true => DefinitionType::PropertyDefinition,
+                        false => DefinitionType::VariableDefinition,
+                    };
+
                     if let Some(pattern_node) = child.child_by_field_name("pattern") {
                         // Find identifiers in the pattern node
                         let identifiers = self.find_identifier_nodes_in_node(pattern_node);
                         for identifier_node in identifiers {
-                            let mut def = Definition::new(
-                                &identifier_node,
-                                source,
-                                DefinitionType::VariableDefinition,
-                            );
+                            let mut def =
+                                Definition::new(&identifier_node, source, definition_type.clone());
                             def.set_context(
                                 scope,
                                 &crate::models::Accessibility::ScopeLocal,
@@ -333,6 +336,28 @@ impl TypeScriptDefinitionExtractor {
             }
         }
         definitions
+    }
+
+    /// Only a constructor can declare properties through its parameters.
+    fn is_constructor_parameter_list(&self, node: Node, source: &str) -> bool {
+        node.parent()
+            .filter(|parent| parent.kind() == "method_definition")
+            .and_then(|method| method.child_by_field_name("name"))
+            .and_then(|name| name.utf8_text(source.as_bytes()).ok())
+            .is_some_and(|name| name == "constructor")
+    }
+
+    /// `constructor(public value: number)` declares a class property as well as a parameter.
+    ///
+    /// An accessibility modifier is a named node, whereas `readonly` is an anonymous token, so
+    /// both named and unnamed children have to be considered.
+    fn declares_property(&self, parameter: Node) -> bool {
+        let mut cursor = parameter.walk();
+        let has_modifier = parameter
+            .children(&mut cursor)
+            .any(|child| matches!(child.kind(), "accessibility_modifier" | "readonly"));
+
+        has_modifier
     }
 
     #[allow(clippy::only_used_in_recursion)]

--- a/crates/core/tests/integration/language/typescript/snapshots/integration_tests__integration__language__typescript__class_method_dependency_ir.snap
+++ b/crates/core/tests/integration/language/typescript/snapshots/integration_tests__integration__language__typescript__class_method_dependency_ir.snap
@@ -78,12 +78,12 @@ IntermediateRepresentation {
     definitions: [
         Definition { position: { 1:7 to 1:14 }, name: "MyClass", definition_type: ClassDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
         Definition { position: { 2:5 to 2:16 }, name: "constructor", definition_type: MethodDefinition, scope_id: Some(2), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
-        Definition { position: { 2:24 to 2:29 }, name: "value", definition_type: VariableDefinition, scope_id: Some(2), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+        Definition { position: { 2:24 to 2:29 }, name: "value", definition_type: PropertyDefinition, scope_id: Some(2), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
         Definition { position: { 3:5 to 3:10 }, name: "greet", definition_type: MethodDefinition, scope_id: Some(3), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
         Definition { position: { 5:5 to 5:13 }, name: "instance", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [
-        Dependency { source_line: 3, target_line: 2, symbol: "value", dependency_type: VariableUse, context: Some("FieldExpression:3:32") },
+        Dependency { source_line: 3, target_line: 2, symbol: "value", dependency_type: StructFieldAccess, context: Some("field_access") },
         Dependency { source_line: 5, target_line: 1, symbol: "MyClass", dependency_type: TypeReference, context: Some("Identifier:5:20") },
         Dependency { source_line: 6, target_line: 5, symbol: "instance", dependency_type: VariableUse, context: Some("Identifier:6:1") },
         Dependency { source_line: 6, target_line: 3, symbol: "greet", dependency_type: FunctionCall, context: Some("FieldExpression:6:10") },

--- a/crates/core/tests/unit/languages/typescript/mod.rs
+++ b/crates/core/tests/unit/languages/typescript/mod.rs
@@ -1,1 +1,2 @@
 pub mod dependency_resolver;
+pub mod parameter_property_tests;

--- a/crates/core/tests/unit/languages/typescript/parameter_property_tests.rs
+++ b/crates/core/tests/unit/languages/typescript/parameter_property_tests.rs
@@ -1,0 +1,90 @@
+use lintric_core::models::{DefinitionType, DependencyType};
+use lintric_core::{analyze_content, Language};
+
+#[test]
+fn registers_a_parameter_with_an_accessibility_modifier_as_a_property() {
+    let source = "class C {\n    constructor(public value: number) {}\n}\n";
+
+    assert_eq!(
+        definition_type(source, "value"),
+        Some(DefinitionType::PropertyDefinition)
+    );
+}
+
+#[test]
+fn registers_a_readonly_parameter_as_a_property() {
+    // `readonly` is an anonymous token, unlike the accessibility modifiers.
+    let source = "class C {\n    constructor(readonly value: number) {}\n}\n";
+
+    assert_eq!(
+        definition_type(source, "value"),
+        Some(DefinitionType::PropertyDefinition)
+    );
+}
+
+#[test]
+fn registers_a_parameter_with_combined_modifiers_as_a_property() {
+    let source = "class C {\n    constructor(private readonly value: number) {}\n}\n";
+
+    assert_eq!(
+        definition_type(source, "value"),
+        Some(DefinitionType::PropertyDefinition)
+    );
+}
+
+#[test]
+fn leaves_an_unmodified_constructor_parameter_a_variable() {
+    let source = "class C {\n    constructor(value: number) {}\n}\n";
+
+    assert_eq!(
+        definition_type(source, "value"),
+        Some(DefinitionType::VariableDefinition)
+    );
+}
+
+#[test]
+fn leaves_a_plain_function_parameter_a_variable() {
+    let source = "function f(value: number): number {\n    return value;\n}\n";
+
+    assert_eq!(
+        definition_type(source, "value"),
+        Some(DefinitionType::VariableDefinition)
+    );
+}
+
+#[test]
+fn leaves_a_method_parameter_a_variable() {
+    // Only a constructor can declare properties through its parameters.
+    let source = "class C {\n    set(value: number) {}\n}\n";
+
+    assert_eq!(
+        definition_type(source, "value"),
+        Some(DefinitionType::VariableDefinition)
+    );
+}
+
+#[test]
+fn classifies_reading_a_parameter_property_as_a_field_access() {
+    let source = "class C {\n    constructor(public value: number) {}\n    get(): number {\n        return this.value;\n    }\n}\n";
+    let (ir, _) = analyze_content(source.to_string(), Language::TypeScript).unwrap();
+
+    let dependency = ir
+        .dependencies
+        .iter()
+        .find(|dependency| dependency.source_line == 4 && dependency.target_line == 2)
+        .expect("this.value should depend on the parameter property");
+
+    assert_eq!(
+        dependency.dependency_type,
+        DependencyType::StructFieldAccess
+    );
+}
+
+fn definition_type(source: &str, name: &str) -> Option<DefinitionType> {
+    let (ir, _) = analyze_content(source.to_string(), Language::TypeScript).unwrap();
+
+    ir.definitions
+        .iter()
+        .find(|definition| definition.name == name)
+        .map(|definition| definition.definition_type.clone())
+}


### PR DESCRIPTION
close: #184

## Problem

`constructor(public value: number)` declares a class property, not merely a parameter, but it was registered as a `VariableDefinition`:

```
Definition { position: { 2:24 to 2:29 }, name: "value", definition_type: VariableDefinition }
```

The dependency itself resolved, so no edge was lost and the accuracy harness never saw this. What was wrong was the classification — and after #173 made `DependencyType` follow the resolved definition, it became visible in output: `this.value` reported `VariableUse` where a property read belongs.

## Approach

Detect the modifiers that turn a constructor parameter into a property.

The two modifier forms are represented differently in the grammar, which is the one subtlety here:

- `accessibility_modifier` (`public` / `private` / `protected`) is a **named** node
- `readonly` is an **anonymous** token — `"named": false` in `node-types.json`, and it does not appear in `required_parameter`'s named children at all

So `child_by_field_name` and named-child iteration both miss `readonly`. The check walks all children, named and unnamed.

Restricted in two ways to match TypeScript's actual rule:

- only constructor parameter lists, since no other parameter list can declare properties
- only parameters that carry a modifier, since a plain `constructor(value: number)` declares nothing

## Result

```
class C {
    constructor(public a: number, private readonly b: string, c: boolean) {}
    get(): number { return this.a; }
}
```

```
L2 'a' PropertyDefinition     <- public
L2 'b' PropertyDefinition     <- private readonly
L2 'c' VariableDefinition     <- no modifier
L3 -> L2 'a' (StructFieldAccess)
```

`constructor(readonly d: number)` with no accessibility modifier also resolves to a property, which is the case the anonymous-token handling exists for.

## Snapshot changes

One file, two lines — exactly the case #184 was filed from, changing in both the ways the fix predicts:

```diff
- Definition { ... name: "value", definition_type: VariableDefinition ... }
+ Definition { ... name: "value", definition_type: PropertyDefinition ... }
- Dependency { source_line: 3, target_line: 2, symbol: "value", dependency_type: VariableUse, context: Some("FieldExpression:3:32") }
+ Dependency { source_line: 3, target_line: 2, symbol: "value", dependency_type: StructFieldAccess, context: Some("field_access") }
```

The context changes because resolution now takes the TypeScript method resolver's field-access path, whose guard requires a `PropertyDefinition`. No resolver change was needed, as #184 anticipated.

## Verification

- 7 new tests in `crates/core/tests/unit/languages/typescript/parameter_property_tests.rs`: accessibility modifier, `readonly` alone, combined modifiers, unmodified constructor parameter, plain function parameter, non-constructor method parameter, and the resulting field-access classification
- Full suite 800 passing
- Accuracy unchanged at precision 1.000 / recall 1.000
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

Note: `cargo clippy --workspace --all-targets` reports pre-existing warnings in test files unrelated to this change. None are in files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)