### PR TITLE
test(accuracy): grow the fixture set, and correct the README about snapshots

### DIFF
--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -5,14 +5,24 @@ baseline so that changes in detection behaviour are visible in diffs.
 
 ## Why this exists
 
-The rest of the test suite cannot answer "how accurate are we?". Snapshot tests record whatever
-the analyzer currently outputs, so wrong output is locked in as faithfully as right output. The
-generated tests in `crates/test-generator` assert that a node kind analyzes without panicking,
-which is a useful crash net but silent about correctness.
+This crate does **not** replace the snapshot suite, and covers far less ground than it does. The
+352 snapshots across `crates/core`, `crates/cli` and `crates/test-generator` exercise a much wider
+range of constructs than the fixtures here, and they remain the right tool for detecting that
+analysis output changed at all — a behaviour-preserving refactor should leave every one of them
+untouched.
+
+What they cannot answer is "how accurate are we?". A snapshot records whatever the analyzer
+currently outputs, so wrong output is locked in as faithfully as right output. Every defect fixed
+in #171, #172, #175, #176 and #177 sat inside green snapshots as an accepted expected value — a
+trait method declaration recorded as a usage, `dependent_lines: [1, 1, 1]` for a line depending on
+one line. Nothing was failing.
 
 This crate takes the opposite approach: expectations are written by hand from the language's
-semantics, **independent of what the analyzer currently produces**. That makes it possible to
-report precision and recall rather than merely detecting change.
+semantics, **independent of what the analyzer currently produces**. That is what makes precision
+and recall meaningful, and what lets a diff say whether a change was an improvement rather than
+just a change.
+
+Use both. Snapshots tell you something moved; these fixtures tell you which direction.
 
 ## Running it
 
@@ -76,35 +86,49 @@ only integer counts and does not churn on float formatting.
 
 ## Interpreting the baseline
 
-The recorded numbers describe **these fixtures only**. They currently read 1.000 for both
-precision and recall, which is a statement about the fixtures rather than about the analyzer:
-every construct these files cover is handled, and every construct they do not cover is
-unmeasured.
+The recorded numbers describe **these fixtures only**, and are not an accuracy claim for the
+analyzer as a whole. Constructs the fixtures do not reach are simply unmeasured — lifetimes,
+async, trait objects, and most of TypeScript's type system have no fixtures yet.
 
-A perfect score is therefore a signal that the fixture set needs growing, not that dependency
-detection is finished. Imports, generics, lifetimes, nested modules, async, and most of
-TypeScript's type system have no fixtures at all. Adding them is expected to push the numbers
-*down*, and that is the intended direction — it means the harness is measuring more of what the
-analyzer actually has to handle.
+Growing the fixture set is expected to push the numbers *down*, and that is the intended
+direction: it means the harness is measuring more of what the analyzer actually has to handle. It
+has already worked that way. Precision stood at 1.000 across every fixture until
+`rust/nested_scopes.rs` was added, which produced the first spurious edge ever recorded (#187) and
+falsified the assumption that the analyzer only ever under-reports.
 
-## Deliberately unsettled
+A near-perfect score is therefore a signal to add fixtures, not a sign that detection is
+finished.
 
-Import and cross-scope resolution is not covered yet, because the expected shape is a design
-question rather than a fact about the language. Given
+## Import resolution
+
+Given
 
 ```rust
 mod geometry {
     pub struct Rect { pub width: i32 }
 }
-use geometry::Rect;
+use geometry::Rect;          // L4
 
 fn main() {
     let r = Rect { width: 1 };
 }
 ```
 
-it is unclear whether `Rect` in `main` should depend on the `use` line (treating the import as
-the local binding) or directly on the struct definition. #87 proposes that import-like
-dependencies be placed at the top scope level, which implies the former, but this has not been
-decided. Fixtures for modules and imports should be added once it is, so that the baseline does
-not encode an accidental answer.
+`Rect` in `main` depends on the **`use` line**, and the `use` line depends on the struct
+definition. The chain, rather than a direct edge to the definition, is deliberate:
+
+- a `use` statement creates a local binding, and that binding is what the reference names
+- both edges are real: changing the `use` line breaks the reference, and renaming the struct
+  breaks the `use` line
+- transitive metrics recover the full chain anyway, so nothing is lost by going through it
+- it agrees with #87's proposal that import-like dependencies belong at the top scope level
+
+This was an open question when the harness was written, and `rust/imports.rs` now pins the
+answer. It is a decision rather than a fact about the language, so it is revisitable — but it
+should be revisited by changing that fixture, not by discovering that behaviour drifted.
+
+## Still unsettled
+
+Whether a functional update, `Point { ..other }`, should imply a dependency on every field
+declaration of the struct. It currently reads only the base expression, pinned by a test in
+`crates/core/tests/unit/languages/rust/field_initializer_tests.rs`.

--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -24,10 +24,42 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "rust/generics.rs": {
+      "expected": 10,
+      "detected": 10,
+      "correct": 10,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "rust/imports.rs": {
+      "expected": 12,
+      "detected": 12,
+      "correct": 12,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 2
+    },
     "rust/macros.rs": {
       "expected": 9,
       "detected": 9,
       "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "rust/nested_scopes.rs": {
+      "expected": 5,
+      "detected": 5,
+      "correct": 4,
+      "missing": 1,
+      "spurious": 1,
+      "duplicates": 0
+    },
+    "rust/patterns.rs": {
+      "expected": 14,
+      "detected": 14,
+      "correct": 14,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -64,6 +96,14 @@
       "spurious": 0,
       "duplicates": 0
     },
+    "tsx/props.tsx": {
+      "expected": 6,
+      "detected": 6,
+      "correct": 6,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/classes.ts": {
       "expected": 9,
       "detected": 9,
@@ -72,11 +112,27 @@
       "spurious": 0,
       "duplicates": 2
     },
+    "typescript/enums.ts": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 4
+    },
     "typescript/functions.ts": {
       "expected": 7,
       "detected": 7,
       "correct": 7,
       "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
+    "typescript/interfaces.ts": {
+      "expected": 10,
+      "detected": 9,
+      "correct": 9,
+      "missing": 1,
       "spurious": 0,
       "duplicates": 1
     },
@@ -90,11 +146,11 @@
     }
   },
   "total": {
-    "expected": 99,
-    "detected": 99,
-    "correct": 99,
-    "missing": 0,
-    "spurious": 0,
-    "duplicates": 10
+    "expected": 165,
+    "detected": 164,
+    "correct": 163,
+    "missing": 2,
+    "spurious": 1,
+    "duplicates": 17
   }
 }

--- a/crates/accuracy/fixtures/rust/generics.rs
+++ b/crates/accuracy/fixtures/rust/generics.rs
@@ -1,0 +1,24 @@
+// Generic parameters and trait bounds.
+
+trait Shape {
+    fn area(&self) -> i32;
+}
+
+struct Square {
+    side: i32,
+}
+
+impl Shape for Square { //~ depends: Shape@3, Square@7
+    fn area(&self) -> i32 { //~ depends: area@4
+        self.side //~ depends: side@8
+    }
+}
+
+fn largest<T: Shape>(items: &[T]) -> i32 { //~ depends: Shape@3
+    items.len() as i32 //~ depends: items@17
+}
+
+fn main() {
+    let s = Square { side: 2 }; //~ depends: Square@7, side@8
+    let _ = largest(&[s]); //~ depends: largest@17, s@22
+}

--- a/crates/accuracy/fixtures/rust/imports.rs
+++ b/crates/accuracy/fixtures/rust/imports.rs
@@ -1,0 +1,22 @@
+// Module declarations, imports and qualified paths.
+//
+// A `use` statement creates a local binding, so a reference resolves to the import line and the
+// import line resolves to the definition. See "Import resolution" in the crate README.
+
+mod geometry {
+    pub struct Rect {
+        pub width: i32,
+    }
+
+    pub fn unit() -> Rect { //~ depends: Rect@7
+        Rect { width: 1 } //~ depends: Rect@7, width@8
+    }
+}
+
+use geometry::Rect; //~ depends: geometry@6, Rect@7
+
+fn main() {
+    let direct = geometry::unit(); //~ depends: geometry@6, unit@11
+    let imported = Rect { width: 2 }; //~ depends: Rect@16, width@8
+    let _ = direct.width + imported.width; //~ depends: direct@19, imported@20, width@8
+}

--- a/crates/accuracy/fixtures/rust/nested_scopes.rs
+++ b/crates/accuracy/fixtures/rust/nested_scopes.rs
@@ -1,0 +1,21 @@
+// Nested blocks, shadowing and nested function items.
+
+fn main() {
+    let outer = 1;
+    let shadowed = 2;
+    {
+        let inner = outer + 1; //~ depends: outer@4
+        let shadowed = inner; //~ depends: inner@7
+        let _ = shadowed; //~ depends: shadowed@8
+    }
+    // The block-scoped binding is out of scope again, so this reads the outer one.
+    let _ = shadowed; //~ depends: shadowed@5
+}
+
+fn nesting() -> i32 {
+    fn inner() -> i32 {
+        1
+    }
+
+    inner() //~ depends: inner@16
+}

--- a/crates/accuracy/fixtures/rust/patterns.rs
+++ b/crates/accuracy/fixtures/rust/patterns.rs
@@ -1,0 +1,21 @@
+// Match arms, if let and pattern bindings.
+
+enum Value {
+    Number(i32),
+    Text,
+}
+
+fn describe(value: Value) -> i32 { //~ depends: Value@3
+    match value { //~ depends: value@8
+        Value::Number(n) => n, //~ depends: Value@3, Number@4
+        Value::Text => 0, //~ depends: Value@3, Text@5
+    }
+}
+
+fn main() {
+    let v = Value::Number(1); //~ depends: Value@3, Number@4
+    let n = describe(v); //~ depends: describe@8, v@16
+    if let Value::Text = v { //~ depends: Value@3, Text@5, v@16
+        let _ = n; //~ depends: n@17
+    }
+}

--- a/crates/accuracy/fixtures/tsx/props.tsx
+++ b/crates/accuracy/fixtures/tsx/props.tsx
@@ -1,0 +1,16 @@
+// Component props and nested JSX elements.
+
+interface LabelProps {
+    text: string;
+}
+
+function Label(props: LabelProps): JSX.Element { //~ depends: LabelProps@3
+    return <span>{props.text}</span>; //~ depends: props@7, text@4
+}
+
+const greeting = "hello";
+
+function App(): JSX.Element {
+    // The attribute name references the declared prop: renaming it at line 4 breaks this line.
+    return <Label text={greeting} />; //~ depends: Label@7, greeting@11, text@4
+}

--- a/crates/accuracy/fixtures/typescript/enums.ts
+++ b/crates/accuracy/fixtures/typescript/enums.ts
@@ -1,0 +1,13 @@
+// Enum declarations and member references.
+
+enum Direction {
+    Left,
+    Right,
+}
+
+function flip(direction: Direction): Direction { //~ depends: Direction@3
+    return direction === Direction.Left ? Direction.Right : Direction.Left; //~ depends: direction@8, Direction@3, Left@4, Right@5
+}
+
+const start = Direction.Left; //~ depends: Direction@3, Left@4
+const end = flip(start); //~ depends: flip@8, start@12

--- a/crates/accuracy/fixtures/typescript/interfaces.ts
+++ b/crates/accuracy/fixtures/typescript/interfaces.ts
@@ -1,0 +1,22 @@
+// Interfaces, type aliases and implementations.
+
+interface Shape {
+    area(): number;
+}
+
+type Size = number;
+
+class Square implements Shape { //~ depends: Shape@3
+    side: Size; //~ depends: Size@7
+
+    constructor(side: Size) { //~ depends: Size@7
+        this.side = side; //~ depends: side@10, side@12
+    }
+
+    area(): number { //~ depends: area@4
+        return this.side * this.side; //~ depends: side@10
+    }
+}
+
+const s = new Square(2); //~ depends: Square@9
+const a = s.area(); //~ depends: area@16, s@21


### PR DESCRIPTION
## Why

Two things prompted this.

**The README oversold this crate.** It read as though the snapshot suite were the weaker option. It is not: there are **352 snapshots** across `crates/core`, `crates/cli` and `crates/test-generator`, and 20 real fixture source files already covering imports, generics, macros, closures, pattern matching, hoisting and UFCS. For a behaviour-preserving refactor such as #170, those snapshots are the primary safety net — every one of them should stay untouched — and they cover far more ground than the fixtures here ever will.

What snapshots cannot do is say whether a change was an *improvement*. The README now says that, and says to use both.

It also claimed imports and generics "have no fixtures at all". That was about this crate, but read as a claim about the project, which has had `use_statements_dependency.rs` and `advanced_generics` since long before this crate existed.

**The fixture set was too narrow to justify recall 1.000.** So it grew.

## New fixtures

| Fixture | Covers |
| --- | --- |
| `rust/imports.rs` | `mod`, `use`, qualified paths |
| `rust/generics.rs` | generic parameters, trait bounds |
| `rust/patterns.rs` | match arms, `if let`, pattern bindings |
| `rust/nested_scopes.rs` | nested blocks, shadowing, nested `fn` items |
| `typescript/interfaces.ts` | interfaces, `implements`, type aliases |
| `typescript/enums.ts` | enum declarations and member references |
| `tsx/props.tsx` | component props, nested JSX elements |

Expected edges: 99 → **165**.

## Findings

### #187 — a function beats a shadowing local binding, and beats scope itself

The important one, and the **first spurious edge the harness has ever recorded**:

```
missing:  L8 -> L7  "inner"
spurious: L8 -> L16 "inner"
```

Reduced to a minimal case:

```rust
fn main() {
    let x = 1;              // L2
    let y = x;              // L3  →  resolves to L7, not L2
}

fn other() {
    fn x() -> i32 { 1 }     // L7  —  not even in scope here
}
```

Two failures, separated by probing: definition-type preference overrides shadowing, *and* accessibility fails to exclude a function nested inside an unrelated function. With no competing definition, resolution is correct.

This **falsifies a claim I made earlier in the README** — that the analyzer under-reports rather than over-reports, since precision had stood at 1.000 across every fixture. It creates wrong edges too, and a wrong edge is worse than a missing one: the metrics then charge distance and depth against a relationship that does not exist. The README no longer says otherwise.

### #188 — TypeScript `implements` methods are not linked to their declarations

The counterpart of the Rust fix in #175. `class Square implements Shape` resolves, but `area()` in the class has no edge to `area()` in the interface. The two languages now disagree about a relationship they both have.

### One finding was my own error, not the analyzer's

`tsx/props.tsx` reported a spurious `L14 -> L4 'text'` for `<Label text={greeting} />`. On inspection the edge is real — renaming `text` in `LabelProps` breaks that line — so the annotation was incomplete, not the analyzer wrong.

Verified it is not blind name matching: an attribute matching no declared member (`<L unrelated={1} />`) produces no edge. Annotation corrected, with a comment recording why.

## Recorded baseline

```
TOTAL   expected 165  detected 164  correct 163  missing 2  spurious 1  duplicates 17
        precision 0.994  recall 0.988
```

Both numbers move **down** from 1.000, which is the intended direction — the fixtures now reach further. The two missing edges are #187 and #188; the one spurious edge is #187.

## Import resolution is now a decision, not an open question

The README listed this as unsettled, because a reference could plausibly depend on the `use` line or directly on the definition. `rust/imports.rs` pins the first, and it passes 12/12:

- a `use` statement creates a local binding, and that binding is what the reference names
- both edges are real — changing the `use` line breaks the reference, renaming the struct breaks the `use` line
- transitive metrics recover the chain, so nothing is lost by going through it
- it agrees with #87's proposal that import-like dependencies belong at the top scope level

Still unsettled and documented as such: whether `Point { ..other }` implies a dependency on every field declaration.

## Verification

- Full suite 800 passing, unchanged
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean
- No production code touched; this is fixtures, baseline and documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)