### PR TITLE
fix(core): let scope decide before definition type does

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -51,9 +51,9 @@
     "rust/nested_scopes.rs": {
       "expected": 5,
       "detected": 5,
-      "correct": 4,
-      "missing": 1,
-      "spurious": 1,
+      "correct": 5,
+      "missing": 0,
+      "spurious": 0,
       "duplicates": 0
     },
     "rust/patterns.rs": {
@@ -148,9 +148,9 @@
   "total": {
     "expected": 165,
     "detected": 164,
-    "correct": 163,
-    "missing": 2,
-    "spurious": 1,
+    "correct": 164,
+    "missing": 1,
+    "spurious": 0,
     "duplicates": 17
   }
 }

--- a/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
@@ -396,9 +396,16 @@ impl RustDependencyResolver {
             return true;
         }
 
-        // Check for hoisting rules first
+        // A hoisted definition is visible ahead of its own declaration, but only within the scope
+        // that declares it: a `fn` nested inside another function is not reachable from outside.
+        //
+        // This applies to bare names only. A member reached through a path or a receiver is
+        // reachable by qualification rather than by lexical nesting, so scope must not exclude it.
         if self.is_hoisted_basic(definition) {
-            return true;
+            return match self.is_reached_lexically(usage, definition) {
+                true => self.is_in_scope_chain(usage, definition),
+                false => true,
+            };
         }
 
         // For variable definitions, check scope accessibility
@@ -429,6 +436,100 @@ impl RustDependencyResolver {
         }
 
         true
+    }
+
+    /// Whether lexical scope governs how this usage finds this definition.
+    ///
+    /// A bare identifier is looked up lexically. A path or a receiver reaches its target by
+    /// qualification instead, and so does a method: a method is never found by bare lexical
+    /// lookup, which matters inside macro token trees where `c.get()` is not parsed as a call and
+    /// its method name arrives as a bare identifier.
+    fn is_reached_lexically(&self, usage: &Usage, definition: &Definition) -> bool {
+        let bare_name = matches!(usage.kind, crate::models::UsageKind::Identifier)
+            && !matches!(
+                usage.context.as_deref(),
+                Some("scoped_identifier") | Some("field_expression")
+            );
+
+        bare_name
+            && !matches!(
+                definition.definition_type,
+                crate::models::DefinitionType::MethodDefinition
+            )
+    }
+
+    /// Whether the definition sits in the usage's scope or one enclosing it.
+    ///
+    /// An item that creates a scope has its own name recorded inside that scope rather than
+    /// alongside it, so a top-level `fn` is registered in the function's own scope. The parent
+    /// therefore counts too, otherwise no such item would ever look reachable.
+    fn is_in_scope_chain(&self, usage: &Usage, definition: &Definition) -> bool {
+        let chain = self.usage_scope_chain(usage);
+
+        definition.scope_id.is_some_and(|def_scope| {
+            chain.contains(&def_scope)
+                || self
+                    .parent_scope(def_scope)
+                    .is_some_and(|parent| chain.contains(&parent))
+        })
+    }
+
+    fn parent_scope(&self, scope_id: ScopeId) -> Option<ScopeId> {
+        self.symbol_table
+            .scopes
+            .get_scope(scope_id)
+            .and_then(|scope| scope.parent)
+    }
+
+    /// The definition in the scope nearest the usage.
+    ///
+    /// A bare identifier names the nearest binding in scope, so proximity decides before
+    /// definition type does: a `let` binding in the enclosing block shadows a function item of the
+    /// same name declared further out.
+    fn select_nearest_in_scope_chain<'a>(
+        &self,
+        usage: &Usage,
+        matching_definitions: &[&'a Definition],
+    ) -> Option<&'a Definition> {
+        self.usage_scope_chain(usage)
+            .iter()
+            .find_map(|scope_id| self.select_within_scope(usage, matching_definitions, *scope_id))
+    }
+
+    /// Within one scope, the binding named is the last one declared before the usage: a later
+    /// `let` of the same name shadows an earlier one. A hoisted definition is visible even when
+    /// declared afterwards, so it is the fallback when nothing precedes.
+    fn select_within_scope<'a>(
+        &self,
+        usage: &Usage,
+        matching_definitions: &[&'a Definition],
+        scope_id: ScopeId,
+    ) -> Option<&'a Definition> {
+        let in_scope: Vec<&'a Definition> = matching_definitions
+            .iter()
+            .filter(|def| def.scope_id == Some(scope_id))
+            .copied()
+            .collect();
+
+        in_scope
+            .iter()
+            .filter(|def| def.position.start_line < usage.position.start_line)
+            .max_by_key(|def| def.position.start_line)
+            .copied()
+            .or_else(|| in_scope.first().copied())
+    }
+
+    /// The usage's own scope followed by its enclosing scopes, nearest first.
+    fn usage_scope_chain(&self, usage: &Usage) -> Vec<ScopeId> {
+        let usage_scope = self
+            .symbol_table
+            .scopes
+            .find_scope_at_position(&usage.position)
+            .unwrap_or(0);
+
+        std::iter::once(usage_scope)
+            .chain(self.symbol_table.scopes.get_parent_scopes(usage_scope))
+            .collect()
     }
 
     fn is_hoisted_basic(&self, definition: &Definition) -> bool {
@@ -1056,6 +1157,14 @@ impl RustDependencyResolver {
                 ) {
                     return Some(def);
                 }
+            }
+        }
+
+        // A bare identifier names the nearest binding in scope, so shadowing decides before the
+        // definition-type ladder below gets a say.
+        if matches!(usage.kind, crate::models::UsageKind::Identifier) {
+            if let Some(nearest) = self.select_nearest_in_scope_chain(usage, matching_definitions) {
+                return Some(nearest);
             }
         }
 

--- a/crates/core/tests/unit/languages/rust/mod.rs
+++ b/crates/core/tests/unit/languages/rust/mod.rs
@@ -3,3 +3,4 @@ pub mod dependency_type_tests;
 pub mod enum_variant_tests;
 pub mod field_initializer_tests;
 pub mod format_string_tests;
+pub mod scope_precedence_tests;

--- a/crates/core/tests/unit/languages/rust/scope_precedence_tests.rs
+++ b/crates/core/tests/unit/languages/rust/scope_precedence_tests.rs
@@ -1,0 +1,75 @@
+use lintric_core::{analyze_content, Language};
+
+#[test]
+fn a_local_binding_shadows_a_top_level_function_of_the_same_name() {
+    let source = "fn main() {\n    let x = 1;\n    let y = x;\n}\n\nfn x() -> i32 {\n    1\n}\n";
+
+    assert_eq!(targets(source, 3, "x"), vec![2]);
+}
+
+#[test]
+fn a_function_nested_in_another_function_is_out_of_reach() {
+    let source = "fn main() {\n    let x = 1;\n    let y = x;\n}\n\nfn other() {\n    fn x() -> i32 {\n        1\n    }\n}\n";
+
+    assert_eq!(targets(source, 3, "x"), vec![2]);
+}
+
+#[test]
+fn the_latest_preceding_binding_wins_within_one_scope() {
+    let source = "fn main() {\n    let a = 1;\n    let a = 2;\n    let b = a;\n}\n";
+
+    assert_eq!(targets(source, 4, "a"), vec![3]);
+}
+
+#[test]
+fn a_rebinding_reads_the_binding_it_shadows() {
+    let source = "fn main() {\n    let a = 1;\n    let a = a + 1;\n}\n";
+
+    assert_eq!(targets(source, 3, "a"), vec![2]);
+}
+
+#[test]
+fn a_binding_shadowed_inside_a_block_is_readable_again_after_it() {
+    let source = "fn main() {\n    let a = 1;\n    {\n        let a = 2;\n        let _ = a;\n    }\n    let _ = a;\n}\n";
+
+    assert_eq!(targets(source, 5, "a"), vec![4]);
+    assert_eq!(targets(source, 7, "a"), vec![2]);
+}
+
+#[test]
+fn a_call_still_reaches_a_top_level_function() {
+    let source = "fn helper() -> i32 {\n    1\n}\n\nfn main() {\n    let n = helper();\n}\n";
+
+    assert_eq!(targets(source, 6, "helper"), vec![1]);
+}
+
+#[test]
+fn a_qualified_path_still_reaches_a_function_inside_a_module() {
+    let source = "mod inner {\n    pub fn unit() -> i32 {\n        1\n    }\n}\n\nfn main() {\n    let n = inner::unit();\n}\n";
+
+    assert_eq!(targets(source, 8, "unit"), vec![2]);
+}
+
+#[test]
+fn a_method_call_inside_a_macro_still_reaches_the_method() {
+    // Inside a macro token tree `c.get()` is not parsed as a call, so the method name arrives as
+    // a bare identifier. Lexical scope must not exclude it.
+    let source = "struct C;\n\nimpl C {\n    fn get(&self) -> i32 {\n        1\n    }\n}\n\nfn main() {\n    let c = C;\n    println!(\"{}\", c.get());\n}\n";
+
+    assert_eq!(targets(source, 11, "get"), vec![4]);
+}
+
+fn targets(source: &str, from: usize, symbol: &str) -> Vec<usize> {
+    let (ir, _) = analyze_content(source.to_string(), Language::Rust).unwrap();
+
+    let mut lines: Vec<usize> = ir
+        .dependencies
+        .iter()
+        .filter(|dependency| dependency.source_line == from && dependency.symbol == symbol)
+        .map(|dependency| dependency.target_line)
+        .collect();
+
+    lines.sort();
+    lines.dedup();
+    lines
+}


### PR DESCRIPTION
close: #187

## Problem

A name matching both a local binding and a function resolved to the function — losing the correct edge and producing a wrong one in its place:

```rust
fn main() {
    let x = 1;              // L2
    let y = x;              // L3  →  resolved to L7
}

fn other() {
    fn x() -> i32 { 1 }     // L7  —  not in scope here at all
}
```

This was the only known defect that produced a **wrong** edge rather than a missing one, which is worse: the metrics then charge distance and depth against a relationship that does not exist.

## Two causes

**`is_accessible_basic` treated every hoisted definition as reachable from anywhere.** A `fn` nested inside an unrelated function survived into the candidate set. Now gated on the definition sitting in the usage's scope chain.

**`select_best_definition_by_priority` applied a fixed preference by definition type**, which ignores shadowing entirely. A bare identifier now resolves to the nearest binding first, and within one scope to the last one declared before the usage — so a later `let` shadows an earlier one, and `let a = a + 1` still reads what it shadows.

## Two exemptions, both found by the harness rejecting a first attempt

This is where the accuracy harness earned its keep. The first version fixed the reported bug and broke other things; each break pointed at a real rule.

**1. An item that creates a scope records its own name inside that scope.** A top-level `fn foo` is registered in `foo`'s own scope, not alongside it — the traverser does this deliberately. So a naive scope-chain test made *every* top-level function and enum look unreachable: recall fell to 0.794 with 34 missing edges. The parent of the definition's scope has to count too.

**2. Lexical scope governs bare names only.** Gating everything broke `geometry::unit()` and `p.norm()`, which reach their target by qualification rather than nesting.

Then one further case survived even that, caught as the single edge removed across all snapshots — `calc.get_value()` inside `println!`:

```
usages on that line: [('println', Identifier, None), ('calc', Identifier, None), ('get_value', Identifier, None)]
```

Inside a macro token tree the expression is not parsed as a call, so the method name arrives as a **bare identifier with no context**, indistinguishable from a lexical lookup. Since a method is never found by bare lexical lookup in Rust, methods are exempt from the gate — which covers the macro case without needing to detect macros.

## Result

| | before | after |
| --- | --- | --- |
| recall | 0.988 | **0.994** |
| precision | 0.994 | **1.000** |
| spurious edges | 1 | **0** |

The one remaining missing edge across all fixtures is #188.

**No snapshot changes at all.** None of the 352 existing snapshots move, so the fix closes the accuracy gap without costing behaviour anywhere else.

## Verification

- 8 new tests in `crates/core/tests/unit/languages/rust/scope_precedence_tests.rs`: shadowing a top-level function, a function nested in another function being out of reach, latest-preceding binding within a scope, `let a = a + 1` reading what it shadows, a block-scoped binding being readable again after the block, and three that pin what must keep working — a call to a top-level function, a qualified path into a module, and a method call inside a macro
- Full suite 808 passing
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

## Not addressed

The gate is skipped for `CallExpression`, so a bare call to a function nested inside an unrelated function would still resolve. That is not valid Rust, so it costs nothing real, but it means the fix is about name resolution rather than a complete reachability model. #95 covers the broader scope work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust name resolution so references select the nearest valid binding according to lexical scope and declaration order.
  * Corrected handling of shadowed variables, nested scopes, rebindings, qualified functions, and method calls.

* **Tests**
  * Added coverage for Rust scope precedence and identifier resolution scenarios.
  * Updated accuracy baselines to reflect improved Rust analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->