### PR TITLE
fix(core): link TypeScript class methods to the interface methods they implement

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -130,9 +130,9 @@
     },
     "typescript/interfaces.ts": {
       "expected": 10,
-      "detected": 9,
-      "correct": 9,
-      "missing": 1,
+      "detected": 10,
+      "correct": 10,
+      "missing": 0,
       "spurious": 0,
       "duplicates": 1
     },
@@ -147,9 +147,9 @@
   },
   "total": {
     "expected": 165,
-    "detected": 164,
-    "correct": 164,
-    "missing": 1,
+    "detected": 165,
+    "correct": 165,
+    "missing": 0,
     "spurious": 0,
     "duplicates": 17
   }

--- a/crates/core/src/dependency_resolver/mod.rs
+++ b/crates/core/src/dependency_resolver/mod.rs
@@ -1,3 +1,4 @@
 pub mod base_resolver;
+pub mod trait_implementation;
 
 pub use base_resolver::DependencyResolver as DependencyResolverTrait;

--- a/crates/core/src/dependency_resolver/trait_implementation.rs
+++ b/crates/core/src/dependency_resolver/trait_implementation.rs
@@ -1,0 +1,134 @@
+use crate::models::{Dependency, DependencyType};
+use std::collections::HashMap;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Language, Node, Query, QueryCursor, QueryMatch};
+
+/// Queries locating the two sides of an implementation relationship in one language.
+///
+/// Each must capture `@type` for the trait or interface being named, and `@method` for the method
+/// name. Everything else about the relationship is language independent.
+pub struct Queries {
+    /// Methods an implementing block provides, captured with the type it implements.
+    pub implementations: &'static str,
+    /// Methods a trait or interface declares, captured with its own name.
+    pub declarations: &'static str,
+}
+
+/// Resolve dependencies from a method implementation to the declaration it satisfies.
+///
+/// An implementation couples itself to the contract it satisfies: changing the declaration forces
+/// every implementation to follow. The implementation contains no usage of the declared name, so
+/// this relationship is derived from the structure of the implementing block rather than from name
+/// resolution.
+///
+/// Matching is on the pair of declaring type and method name, so two traits declaring the same
+/// method resolve independently.
+pub fn resolve(
+    queries: &Queries,
+    source_code: &str,
+    root_node: Node,
+) -> Result<Vec<Dependency>, String> {
+    // Taking the language from the tree keeps callers from having to name it, and makes dialects
+    // such as TSX work without a separate entry point.
+    let language = &*root_node.language();
+    let declared = declarations(language, queries.declarations, source_code, root_node)?;
+
+    Ok(
+        methods(language, queries.implementations, source_code, root_node)?
+            .iter()
+            .filter_map(|method| {
+                declared
+                    .get(&(method.type_name.clone(), method.name.clone()))
+                    .map(|line| dependency(method, *line))
+            })
+            .filter(|dependency| dependency.source_line != dependency.target_line)
+            .collect(),
+    )
+}
+
+/// A method named within a trait or interface, or within one of its implementations.
+struct Method {
+    type_name: String,
+    name: String,
+    line: usize,
+}
+
+fn declarations(
+    language: &Language,
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+) -> Result<HashMap<(String, String), usize>, String> {
+    Ok(methods(language, query_source, source_code, root_node)?
+        .into_iter()
+        .map(|method| ((method.type_name, method.name), method.line))
+        .collect())
+}
+
+fn methods(
+    language: &Language,
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+) -> Result<Vec<Method>, String> {
+    let query = Query::new(language, query_source)
+        .map_err(|error| format!("Failed to create trait implementation query: {error}"))?;
+
+    let type_index = capture_index(&query, "type")?;
+    let method_index = capture_index(&query, "method")?;
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
+    let mut found = Vec::new();
+
+    while let Some(query_match) = matches.next() {
+        let type_node = capture(query_match, type_index);
+        let method_node = capture(query_match, method_index);
+
+        if let (Some(type_node), Some(method_node)) = (type_node, method_node) {
+            if let Some(method) = method(source_code, type_node, method_node) {
+                found.push(method);
+            }
+        }
+    }
+
+    Ok(found)
+}
+
+fn capture_index(query: &Query, name: &str) -> Result<u32, String> {
+    query
+        .capture_index_for_name(name)
+        .ok_or_else(|| format!("Query is missing the @{name} capture"))
+}
+
+fn capture<'a>(query_match: &QueryMatch<'a, 'a>, index: u32) -> Option<Node<'a>> {
+    query_match
+        .captures
+        .iter()
+        .find(|capture| capture.index == index)
+        .map(|capture| capture.node)
+}
+
+fn method(source_code: &str, type_node: Node, method_node: Node) -> Option<Method> {
+    Some(Method {
+        type_name: text(source_code, type_node)?,
+        name: text(source_code, method_node)?,
+        line: method_node.start_position().row + 1,
+    })
+}
+
+fn text(source_code: &str, node: Node) -> Option<String> {
+    node.utf8_text(source_code.as_bytes())
+        .ok()
+        .map(str::to_string)
+}
+
+fn dependency(method: &Method, target_line: usize) -> Dependency {
+    Dependency {
+        source_line: method.line,
+        target_line,
+        symbol: method.name.clone(),
+        dependency_type: DependencyType::TraitImplementation,
+        context: Some(format!("trait_implementation::{}", method.type_name)),
+    }
+}

--- a/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
@@ -1,124 +1,27 @@
-use crate::models::{Dependency, DependencyType};
-use std::collections::HashMap;
-use streaming_iterator::StreamingIterator;
-use tree_sitter::{Node, Query, QueryCursor, QueryMatch};
+use crate::dependency_resolver::trait_implementation::{self, Queries};
+use crate::models::Dependency;
+use tree_sitter::Node;
 
-/// Methods an `impl Trait for Type` block provides.
-const IMPLEMENTED_METHODS: &str = r#"
-    (impl_item
-      trait: (type_identifier) @trait
-      body: (declaration_list
-        (function_item name: (identifier) @method)))
-"#;
+const QUERIES: Queries = Queries {
+    implementations: r#"
+        (impl_item
+          trait: (type_identifier) @type
+          body: (declaration_list
+            (function_item name: (identifier) @method)))
+    "#,
+    // An implementation can satisfy a required signature or override a method the trait already
+    // provides a body for, so both count as declarations.
+    declarations: r#"
+        (trait_item
+          name: (type_identifier) @type
+          body: (declaration_list [
+            (function_signature_item name: (identifier) @method)
+            (function_item name: (identifier) @method)
+          ]))
+    "#,
+};
 
-/// Methods a trait declares. An implementation can satisfy a required signature or override a
-/// method the trait already provides a body for, so both count as declarations.
-const TRAIT_DECLARATIONS: &str = r#"
-    (trait_item
-      name: (type_identifier) @trait
-      body: (declaration_list [
-        (function_signature_item name: (identifier) @method)
-        (function_item name: (identifier) @method)
-      ]))
-"#;
-
-/// Resolve dependencies from a trait method implementation to the declaration it satisfies.
-///
-/// `impl Trait for Type { fn method() {} }` couples the implementation to the trait's contract:
-/// changing the declaration forces every implementation to follow. The implementation contains no
-/// usage of the declared name, so this relationship is derived from the structure of the impl
-/// block rather than from name resolution.
+/// Resolve dependencies from a Rust trait method implementation to the declaration it satisfies.
 pub fn resolve(source_code: &str, root_node: Node) -> Result<Vec<Dependency>, String> {
-    let declarations = trait_declarations(source_code, root_node)?;
-
-    Ok(methods(IMPLEMENTED_METHODS, source_code, root_node)?
-        .iter()
-        .filter_map(|method| {
-            declarations
-                .get(&(method.trait_name.clone(), method.name.clone()))
-                .map(|line| dependency(method, *line))
-        })
-        .filter(|dependency| dependency.source_line != dependency.target_line)
-        .collect())
-}
-
-/// A method named within a trait or one of its implementations.
-struct Method {
-    trait_name: String,
-    name: String,
-    line: usize,
-}
-
-fn trait_declarations(
-    source_code: &str,
-    root_node: Node,
-) -> Result<HashMap<(String, String), usize>, String> {
-    Ok(methods(TRAIT_DECLARATIONS, source_code, root_node)?
-        .into_iter()
-        .map(|method| ((method.trait_name, method.name), method.line))
-        .collect())
-}
-
-fn methods(query_source: &str, source_code: &str, root_node: Node) -> Result<Vec<Method>, String> {
-    let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
-    let query = Query::new(&language, query_source)
-        .map_err(|error| format!("Failed to create trait implementation query: {error}"))?;
-
-    let trait_index = capture_index(&query, "trait")?;
-    let method_index = capture_index(&query, "method")?;
-
-    let mut cursor = QueryCursor::new();
-    let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
-    let mut found = Vec::new();
-
-    while let Some(query_match) = matches.next() {
-        let trait_node = capture(query_match, trait_index);
-        let method_node = capture(query_match, method_index);
-
-        if let (Some(trait_node), Some(method_node)) = (trait_node, method_node) {
-            if let Some(method) = method(source_code, trait_node, method_node) {
-                found.push(method);
-            }
-        }
-    }
-
-    Ok(found)
-}
-
-fn capture_index(query: &Query, name: &str) -> Result<u32, String> {
-    query
-        .capture_index_for_name(name)
-        .ok_or_else(|| format!("Query is missing the @{name} capture"))
-}
-
-fn capture<'a>(query_match: &QueryMatch<'a, 'a>, index: u32) -> Option<Node<'a>> {
-    query_match
-        .captures
-        .iter()
-        .find(|capture| capture.index == index)
-        .map(|capture| capture.node)
-}
-
-fn method(source_code: &str, trait_node: Node, method_node: Node) -> Option<Method> {
-    Some(Method {
-        trait_name: text(source_code, trait_node)?,
-        name: text(source_code, method_node)?,
-        line: method_node.start_position().row + 1,
-    })
-}
-
-fn text(source_code: &str, node: Node) -> Option<String> {
-    node.utf8_text(source_code.as_bytes())
-        .ok()
-        .map(str::to_string)
-}
-
-fn dependency(method: &Method, target_line: usize) -> Dependency {
-    Dependency {
-        source_line: method.line,
-        target_line,
-        symbol: method.name.clone(),
-        dependency_type: DependencyType::TraitImplementation,
-        context: Some(format!("trait_implementation::{}", method.trait_name)),
-    }
+    trait_implementation::resolve(&QUERIES, source_code, root_node)
 }

--- a/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
@@ -1,0 +1,24 @@
+use crate::dependency_resolver::trait_implementation::{self, Queries};
+use crate::models::Dependency;
+use tree_sitter::Node;
+
+const QUERIES: Queries = Queries {
+    implementations: r#"
+        (class_declaration
+          (class_heritage
+            (implements_clause (type_identifier) @type))
+          body: (class_body
+            (method_definition name: (property_identifier) @method)))
+    "#,
+    declarations: r#"
+        (interface_declaration
+          name: (type_identifier) @type
+          body: (interface_body
+            (method_signature name: (property_identifier) @method)))
+    "#,
+};
+
+/// Resolve dependencies from a TypeScript class method to the interface method it implements.
+pub fn resolve(source_code: &str, root_node: Node) -> Result<Vec<Dependency>, String> {
+    trait_implementation::resolve(&QUERIES, source_code, root_node)
+}

--- a/crates/core/src/languages/typescript/dependency_resolver/mod.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/mod.rs
@@ -1,3 +1,4 @@
+pub mod interface_implementation_resolver;
 pub mod method_resolver;
 pub mod module_resolver;
 pub mod typescript_dependency_resolver;

--- a/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
@@ -184,6 +184,12 @@ impl DependencyResolverTrait for TypeScriptDependencyResolver {
             all_dependencies.append(&mut deps);
         }
 
+        // Add interface implementation dependencies (class method -> interface declaration), which
+        // have no usage to resolve and are derived from the class heritage instead
+        let implementation_deps =
+            super::interface_implementation_resolver::resolve(source_code, root_node)?;
+        all_dependencies.extend(implementation_deps);
+
         Ok(all_dependencies)
     }
 

--- a/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_class_method_ir.snap
+++ b/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_class_method_ir.snap
@@ -274,6 +274,7 @@ IntermediateRepresentation {
         Dependency { source_line: 34, target_line: 17, symbol: "Circle", dependency_type: TypeReference, context: Some("Identifier:34:24") },
         Dependency { source_line: 35, target_line: 34, symbol: "circle", dependency_type: VariableUse, context: Some("Identifier:35:5") },
         Dependency { source_line: 35, target_line: 24, symbol: "draw", dependency_type: FunctionCall, context: Some("FieldExpression:35:12") },
+        Dependency { source_line: 24, target_line: 14, symbol: "draw", dependency_type: TraitImplementation, context: Some("trait_implementation::Drawable") },
     ],
     usage: [
         Usage { position: { 5:14 to 5:19 }, name: "value", kind: FieldExpression, context: None },

--- a/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
+++ b/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
@@ -1,0 +1,91 @@
+use lintric_core::models::DependencyType;
+use lintric_core::{analyze_content, Language};
+
+#[test]
+fn links_a_class_method_to_the_interface_method_it_implements() {
+    let source = "interface Shape {\n    area(): number;\n}\n\nclass Square implements Shape {\n    area(): number {\n        return 1;\n    }\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(6, 2, "area".to_string())]
+    );
+}
+
+#[test]
+fn links_an_optional_member_like_any_other() {
+    let source = "interface Shape {\n    area?(): number;\n}\n\nclass Square implements Shape {\n    area(): number {\n        return 1;\n    }\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(6, 2, "area".to_string())]
+    );
+}
+
+#[test]
+fn resolves_a_shared_method_name_to_the_interface_being_implemented() {
+    let source = "interface Left {\n    run(): void;\n}\n\ninterface Right {\n    run(): void;\n}\n\nclass S implements Right {\n    run(): void {}\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(10, 6, "run".to_string())]
+    );
+}
+
+#[test]
+fn links_each_method_to_the_interface_that_declares_it() {
+    let source = "interface A {\n    one(): void;\n}\n\ninterface B {\n    two(): void;\n}\n\nclass S implements A, B {\n    one(): void {}\n\n    two(): void {}\n}\n";
+    let dependencies = implementations(source, Language::TypeScript);
+
+    assert!(
+        dependencies.contains(&(10, 2, "one".to_string())),
+        "{dependencies:?}"
+    );
+    assert!(
+        dependencies.contains(&(12, 6, "two".to_string())),
+        "{dependencies:?}"
+    );
+}
+
+#[test]
+fn ignores_a_class_that_implements_nothing() {
+    let source = "class Square {\n    area(): number {\n        return 1;\n    }\n}\n";
+
+    assert!(implementations(source, Language::TypeScript).is_empty());
+}
+
+#[test]
+fn ignores_a_method_the_interface_does_not_declare() {
+    let source = "interface Shape {\n    area(): number;\n}\n\nclass Square implements Shape {\n    area(): number {\n        return 1;\n    }\n\n    extra(): number {\n        return 2;\n    }\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(6, 2, "area".to_string())]
+    );
+}
+
+#[test]
+fn works_in_tsx_as_well_as_typescript() {
+    // The language comes from the parsed tree, so a dialect needs no separate entry point.
+    let source = "interface I {\n    render(): JSX.Element;\n}\n\nclass C implements I {\n    render(): JSX.Element {\n        return <span />;\n    }\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TSX),
+        vec![(6, 2, "render".to_string())]
+    );
+}
+
+fn implementations(source: &str, language: Language) -> Vec<(usize, usize, String)> {
+    let (ir, _) = analyze_content(source.to_string(), language).unwrap();
+
+    ir.dependencies
+        .iter()
+        .filter(|dependency| dependency.dependency_type == DependencyType::TraitImplementation)
+        .map(|dependency| {
+            (
+                dependency.source_line,
+                dependency.target_line,
+                dependency.symbol.clone(),
+            )
+        })
+        .collect()
+}

--- a/crates/core/tests/unit/languages/typescript/mod.rs
+++ b/crates/core/tests/unit/languages/typescript/mod.rs
@@ -1,2 +1,3 @@
 pub mod dependency_resolver;
+pub mod interface_implementation_tests;
 pub mod parameter_property_tests;


### PR DESCRIPTION
close: #188

## Problem

`class Square implements Shape` resolved, but `area()` in the class had no edge to `area()` in the interface. An interface is the contract its implementors depend on, and for TypeScript that coupling was invisible — while the Rust equivalent had been fixed in #175, leaving the two languages disagreeing about a relationship they share.

## Approach

The issue suggested checking whether the matching logic could be shared rather than duplicated. It can: the two languages differ only in *where* the two sides live.

A new language-neutral `crates/core/src/dependency_resolver/trait_implementation.rs` holds the mechanics — running the queries, pairing on declaring type and method name, building the dependency. Each language supplies a pair of queries capturing `@type` and `@method`:

```scheme
; TypeScript
(class_declaration
  (class_heritage
    (implements_clause (type_identifier) @type))
  body: (class_body
    (method_definition name: (property_identifier) @method)))

(interface_declaration
  name: (type_identifier) @type
  body: (interface_body
    (method_signature name: (property_identifier) @method)))
```

The Rust module from #175 becomes the same kind of thin wrapper, so the two are now one implementation with two query pairs rather than two implementations.

**The language comes from the parsed tree** (`root_node.language()`) rather than from the caller. That removes the need for callers to name it and means TSX works with no separate entry point — verified by a test.

## Result

```
TOTAL   expected 165  detected 165  correct 165  missing 0  spurious 0
        precision 1.000  recall 1.000
```

Every accuracy gap the fixtures currently reach is closed. Across the series the harness has gone 0.857 → 0.891 → 0.913 → 0.967 → 1.000 → 0.988 (fixtures grew) → 0.994 → **1.000**.

Matching is on the pair of interface and method name, so a class implementing several interfaces resolves each method to the interface that declares it, and two interfaces declaring the same method resolve independently. Optional members (`area?(): number`) need no special handling.

## Snapshot changes

One file, one edge added, nothing removed:

```
+ Dependency { source_line: 24, target_line: 14, symbol: "draw", dependency_type: TraitImplementation }
```

Checked against the fixture: line 24 is `draw(): void {` in `class Circle implements Drawable`, line 14 is `draw(): void;` in `interface Drawable`.

## Follow-up filed: #191

Only the directly named type is matched. A declaration inherited from a supertype produces nothing — `trait Extended: Base`, `interface Extended extends Base`, and `class Derived extends Base` overriding a base method.

Left out deliberately rather than overlooked: fixing it here would have changed **Rust** behaviour inside a TypeScript-focused change, since both languages now share the resolver. #191 covers both at once, and notes that the harness currently cannot see the gap because no fixture exercises a supertype — so fixtures belong with that fix.

## Verification

- 7 new tests in `crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs`: interface method, optional member, shared method name across two interfaces, several interfaces each declaring one method, a class implementing nothing, a method the interface does not declare, and TSX
- Full suite 815 passing
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

Note: `cargo clippy --workspace --all-targets` reports pre-existing warnings in test files unrelated to this change. None are in files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)