### PR TITLE
feat(core): follow supertypes when resolving a declaration

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -72,6 +72,14 @@
       "spurious": 0,
       "duplicates": 2
     },
+    "rust/supertraits.rs": {
+      "expected": 5,
+      "detected": 5,
+      "correct": 5,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "rust/traits.rs": {
       "expected": 12,
       "detected": 12,
@@ -128,6 +136,14 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "typescript/inheritance.ts": {
+      "expected": 6,
+      "detected": 6,
+      "correct": 6,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/interfaces.ts": {
       "expected": 10,
       "detected": 10,
@@ -146,9 +162,9 @@
     }
   },
   "total": {
-    "expected": 165,
-    "detected": 165,
-    "correct": 165,
+    "expected": 176,
+    "detected": 176,
+    "correct": 176,
     "missing": 0,
     "spurious": 0,
     "duplicates": 17

--- a/crates/accuracy/fixtures/rust/supertraits.rs
+++ b/crates/accuracy/fixtures/rust/supertraits.rs
@@ -1,0 +1,21 @@
+// Declarations inherited from a supertrait.
+
+trait Base {
+    fn run(&self) -> i32;
+}
+
+trait Extended: Base { //~ depends: Base@3
+    fn extra(&self) -> i32;
+}
+
+struct S;
+
+impl Extended for S { //~ depends: Extended@7, S@11
+    fn run(&self) -> i32 { //~ depends: run@4
+        1
+    }
+
+    fn extra(&self) -> i32 { //~ depends: extra@8
+        2
+    }
+}

--- a/crates/accuracy/fixtures/typescript/inheritance.ts
+++ b/crates/accuracy/fixtures/typescript/inheritance.ts
@@ -1,0 +1,25 @@
+// Interface inheritance and class extension.
+
+interface Base {
+    run(): number;
+}
+
+interface Extended extends Base { //~ depends: Base@3
+    extra(): number;
+}
+
+class First implements Extended { //~ depends: Extended@7
+    run(): number { //~ depends: run@4
+        return 1;
+    }
+
+    extra(): number { //~ depends: extra@8
+        return 2;
+    }
+}
+
+class Second extends First { //~ depends: First@11
+    run(): number { //~ depends: run@12
+        return 3;
+    }
+}

--- a/crates/core/src/dependency_resolver/trait_implementation.rs
+++ b/crates/core/src/dependency_resolver/trait_implementation.rs
@@ -1,17 +1,19 @@
 use crate::models::{Dependency, DependencyType};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Language, Node, Query, QueryCursor, QueryMatch};
 
-/// Queries locating the two sides of an implementation relationship in one language.
+/// Queries locating the parts of an implementation relationship in one language.
 ///
-/// Each must capture `@type` for the trait or interface being named, and `@method` for the method
-/// name. Everything else about the relationship is language independent.
+/// Each captures `@type` for the trait, interface or class being named, plus one other capture
+/// named below. Everything else about the relationship is language independent.
 pub struct Queries {
-    /// Methods an implementing block provides, captured with the type it implements.
+    /// Methods an implementing block provides, as `@method`, with the type it implements.
     pub implementations: &'static str,
-    /// Methods a trait or interface declares, captured with its own name.
+    /// Methods a trait or interface declares, as `@method`, with its own name.
     pub declarations: &'static str,
+    /// Types a trait, interface or class inherits, as `@super`, with the inheriting type's name.
+    pub supertypes: &'static str,
 }
 
 /// Resolve dependencies from a method implementation to the declaration it satisfies.
@@ -32,14 +34,13 @@ pub fn resolve(
     // such as TSX work without a separate entry point.
     let language = &*root_node.language();
     let declared = declarations(language, queries.declarations, source_code, root_node)?;
+    let inherited = supertypes(language, queries.supertypes, source_code, root_node)?;
 
     Ok(
         methods(language, queries.implementations, source_code, root_node)?
             .iter()
             .filter_map(|method| {
-                declared
-                    .get(&(method.type_name.clone(), method.name.clone()))
-                    .map(|line| dependency(method, *line))
+                declaration_line(&declared, &inherited, method).map(|line| dependency(method, line))
             })
             .filter(|dependency| dependency.source_line != dependency.target_line)
             .collect(),
@@ -51,6 +52,36 @@ struct Method {
     type_name: String,
     name: String,
     line: usize,
+}
+
+/// The line declaring this method, looked up on the named type and then on what it inherits.
+///
+/// The search is breadth first, so the nearest declaration wins when a type and one of its
+/// supertypes both declare the method. The visited set also keeps an inheritance cycle — invalid
+/// but parseable — from looping.
+fn declaration_line(
+    declared: &HashMap<(String, String), usize>,
+    inherited: &HashMap<String, Vec<String>>,
+    method: &Method,
+) -> Option<usize> {
+    let mut visited: HashSet<&str> = HashSet::new();
+    let mut pending: VecDeque<&str> = VecDeque::from([method.type_name.as_str()]);
+
+    while let Some(type_name) = pending.pop_front() {
+        if !visited.insert(type_name) {
+            continue;
+        }
+
+        if let Some(line) = declared.get(&(type_name.to_string(), method.name.clone())) {
+            return Some(*line);
+        }
+
+        if let Some(supertypes) = inherited.get(type_name) {
+            pending.extend(supertypes.iter().map(String::as_str));
+        }
+    }
+
+    None
 }
 
 fn declarations(
@@ -65,34 +96,82 @@ fn declarations(
         .collect())
 }
 
+fn supertypes(
+    language: &Language,
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+) -> Result<HashMap<String, Vec<String>>, String> {
+    let pairs = map_pairs(
+        language,
+        query_source,
+        source_code,
+        root_node,
+        "super",
+        |type_node, super_node| {
+            Some((
+                text(source_code, type_node)?,
+                text(source_code, super_node)?,
+            ))
+        },
+    )?;
+
+    let mut inherited: HashMap<String, Vec<String>> = HashMap::new();
+    for (type_name, super_name) in pairs {
+        inherited.entry(type_name).or_default().push(super_name);
+    }
+
+    Ok(inherited)
+}
+
 fn methods(
     language: &Language,
     query_source: &str,
     source_code: &str,
     root_node: Node,
 ) -> Result<Vec<Method>, String> {
+    map_pairs(
+        language,
+        query_source,
+        source_code,
+        root_node,
+        "method",
+        |type_node, method_node| method(source_code, type_node, method_node),
+    )
+}
+
+/// Map the `@type` node paired with the other named capture, for every match of the query.
+///
+/// The mapping happens inside the loop because a captured node's lifetime is tied to the query
+/// cursor, so nodes cannot outlive this call.
+fn map_pairs<T>(
+    language: &Language,
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+    second: &str,
+    mut map: impl FnMut(Node, Node) -> Option<T>,
+) -> Result<Vec<T>, String> {
     let query = Query::new(language, query_source)
         .map_err(|error| format!("Failed to create trait implementation query: {error}"))?;
 
     let type_index = capture_index(&query, "type")?;
-    let method_index = capture_index(&query, "method")?;
+    let second_index = capture_index(&query, second)?;
 
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
-    let mut found = Vec::new();
+    let mut mapped = Vec::new();
 
     while let Some(query_match) = matches.next() {
         let type_node = capture(query_match, type_index);
-        let method_node = capture(query_match, method_index);
+        let second_node = capture(query_match, second_index);
 
-        if let (Some(type_node), Some(method_node)) = (type_node, method_node) {
-            if let Some(method) = method(source_code, type_node, method_node) {
-                found.push(method);
-            }
+        if let (Some(type_node), Some(second_node)) = (type_node, second_node) {
+            mapped.extend(map(type_node, second_node));
         }
     }
 
-    Ok(found)
+    Ok(mapped)
 }
 
 fn capture_index(query: &Query, name: &str) -> Result<u32, String> {

--- a/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
@@ -19,6 +19,13 @@ const QUERIES: Queries = Queries {
             (function_item name: (identifier) @method)
           ]))
     "#,
+    // `trait Extended: Base` inherits Base's declarations, so an implementation of Extended can be
+    // satisfying something Base declared.
+    supertypes: r#"
+        (trait_item
+          name: (type_identifier) @type
+          bounds: (trait_bounds (type_identifier) @super))
+    "#,
 };
 
 /// Resolve dependencies from a Rust trait method implementation to the declaration it satisfies.

--- a/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
@@ -3,18 +3,45 @@ use crate::models::Dependency;
 use tree_sitter::Node;
 
 const QUERIES: Queries = Queries {
+    // A class method can satisfy an interface it implements or override one from the class it
+    // extends, so both heritage clauses name a type whose declarations it may be satisfying.
     implementations: r#"
         (class_declaration
-          (class_heritage
-            (implements_clause (type_identifier) @type))
+          (class_heritage [
+            (implements_clause (type_identifier) @type)
+            (extends_clause value: (identifier) @type)
+          ])
           body: (class_body
             (method_definition name: (property_identifier) @method)))
     "#,
+    // A base class declares by providing a body, so its methods count as declarations alongside
+    // the signatures an interface declares.
     declarations: r#"
-        (interface_declaration
-          name: (type_identifier) @type
-          body: (interface_body
-            (method_signature name: (property_identifier) @method)))
+        [
+          (interface_declaration
+            name: (type_identifier) @type
+            body: (interface_body
+              (method_signature name: (property_identifier) @method)))
+          (class_declaration
+            name: (type_identifier) @type
+            body: (class_body
+              (method_definition name: (property_identifier) @method)))
+        ]
+    "#,
+    // `interface Extended extends Base` and `class Derived extends Base` both inherit
+    // declarations, so a lookup that misses the named type continues into these.
+    supertypes: r#"
+        [
+          (interface_declaration
+            name: (type_identifier) @type
+            (extends_type_clause type: (type_identifier) @super))
+          (class_declaration
+            name: (type_identifier) @type
+            (class_heritage [
+              (extends_clause value: (identifier) @super)
+              (implements_clause (type_identifier) @super)
+            ]))
+        ]
     "#,
 };
 

--- a/crates/core/tests/unit/languages/rust/dependency_resolver/trait_implementation_resolver_tests.rs
+++ b/crates/core/tests/unit/languages/rust/dependency_resolver/trait_implementation_resolver_tests.rs
@@ -79,3 +79,44 @@ fn trait_implementations(source: &str) -> Vec<(usize, usize, String)> {
         })
         .collect()
 }
+
+#[test]
+fn links_an_implementation_to_a_declaration_inherited_from_a_supertrait() {
+    let source = "trait Base {\n    fn run(&self);\n}\n\ntrait Extended: Base {}\n\nstruct S;\n\nimpl Extended for S {\n    fn run(&self) {}\n}\n";
+
+    assert_eq!(
+        trait_implementations(source),
+        vec![(10, 2, "run".to_string())]
+    );
+}
+
+#[test]
+fn follows_a_chain_of_supertraits() {
+    let source = "trait Base {\n    fn run(&self);\n}\n\ntrait Mid: Base {}\n\ntrait Top: Mid {}\n\nstruct S;\n\nimpl Top for S {\n    fn run(&self) {}\n}\n";
+
+    assert_eq!(
+        trait_implementations(source),
+        vec![(12, 2, "run".to_string())]
+    );
+}
+
+#[test]
+fn prefers_the_nearest_declaration_over_an_inherited_one() {
+    let source = "trait Base {\n    fn run(&self);\n}\n\ntrait Mid: Base {\n    fn run(&self);\n}\n\nstruct S;\n\nimpl Mid for S {\n    fn run(&self) {}\n}\n";
+
+    assert_eq!(
+        trait_implementations(source),
+        vec![(12, 6, "run".to_string())]
+    );
+}
+
+#[test]
+fn terminates_on_an_inheritance_cycle() {
+    // Invalid Rust, but it parses, so the walk must not loop.
+    let source = "trait A: B {\n    fn x(&self);\n}\n\ntrait B: A {}\n\nstruct S;\n\nimpl B for S {\n    fn x(&self) {}\n}\n";
+
+    assert_eq!(
+        trait_implementations(source),
+        vec![(10, 2, "x".to_string())]
+    );
+}

--- a/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
+++ b/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
@@ -89,3 +89,34 @@ fn implementations(source: &str, language: Language) -> Vec<(usize, usize, Strin
         })
         .collect()
 }
+
+#[test]
+fn links_a_class_method_to_a_declaration_inherited_from_a_parent_interface() {
+    let source = "interface Base {\n    run(): void;\n}\n\ninterface Extended extends Base {}\n\nclass S implements Extended {\n    run(): void {}\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(8, 2, "run".to_string())]
+    );
+}
+
+#[test]
+fn links_an_override_to_the_base_class_method() {
+    let source = "class Base {\n    run(): void {}\n}\n\nclass Derived extends Base {\n    run(): void {}\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(6, 2, "run".to_string())]
+    );
+}
+
+#[test]
+fn reaches_an_interface_declaration_through_a_base_class() {
+    let source = "interface Shape {\n    area(): number;\n}\n\nclass Base implements Shape {\n    area(): number {\n        return 1;\n    }\n}\n\nclass Derived extends Base {\n    area(): number {\n        return 2;\n    }\n}\n";
+    let dependencies = implementations(source, Language::TypeScript);
+
+    assert!(
+        dependencies.contains(&(12, 6, "area".to_string())),
+        "the nearest declaration is the base class method: {dependencies:?}"
+    );
+}


### PR DESCRIPTION
close: #191

## Problem

An implementation was matched only against the type it names, so a declaration inherited from a supertype produced nothing:

```rust
trait Base {
    fn run(&self);          // L2
}
trait Extended: Base {}

impl Extended for S {
    fn run(&self) {}        // L10  — no edge to L2
}
```

The queries pair `Extended` with `run`, `Extended` declares nothing, so nothing matched. The deeper the hierarchy, the more of the relationship went unrecorded.

## Approach

The lookup now continues into what the named type inherits. Each language supplies a query for its inheritance edges; the walk itself is language independent and lives in the shared resolver.

**Breadth first**, so the nearest declaration wins when a type and one of its supertypes both declare the method — pinned by a test where `trait Mid: Base` redeclares `run` and the implementation resolves to `Mid`'s line rather than `Base`'s.

**Cycle-safe.** `trait A: B` with `trait B: A` is invalid Rust but parses, so a visited set stops the walk looping. Covered by a test that would otherwise hang.

### Per language

**Rust** follows the supertrait bounds of a `trait_item`.

**TypeScript** follows both `interface Extended extends Base` and `class Derived extends Base`. A base class declares by providing a *body* rather than a signature, so class methods now count as declarations alongside interface ones — which makes an override resolve the same way an implementation does:

```typescript
class Base {
    run(): void {}          // L2
}
class Derived extends Base {
    run(): void {}          // L6  →  L2
}
```

It also composes: a class extending a base that implements an interface reaches the interface declaration through the chain, and the base class method wins as the nearer declaration.

### One incidental change

Query execution moved behind a single helper that maps captures **inside** its loop. A captured node's lifetime is tied to the query cursor, so returning nodes from the helper does not compile — the mapping has to happen before the cursor is dropped.

## Result

```
TOTAL   expected 176  detected 176  correct 176  missing 0  spurious 0
        precision 1.000  recall 1.000
```

Expected edges 165 → 176, all detected. **No snapshot changes anywhere** — none of the 352 existing snapshots move.

## Fixtures came with the fix

#191 noted that the harness could not see this gap because no fixture exercised a supertype, which is why recall read 1.000 while the defect was open. Two fixtures close that: `rust/supertraits.rs` and `typescript/inheritance.ts`, the latter covering interface inheritance and class extension together.

That mattered: without them the numbers would have been unchanged before and after, and the fix unverifiable by the harness.

## Verification

- 7 new tests: supertrait declaration, a chain of three traits, nearest declaration winning over an inherited one, cycle termination, parent interface, base class override, and an interface reached through a base class
- Full suite 822 passing
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

## Not addressed

Generic supertypes. `trait Extended: Base<T>` parses the bound as `generic_type` rather than `type_identifier`, so the query does not match it — the same limitation already noted for `impl<T> Trait<T> for Type` in #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)