### PR TITLE
test(accuracy): work through the language specification

### DIFF
--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -141,6 +141,17 @@ should be revisited by changing that fixture, not by discovering that behaviour 
 
 ## Still unsettled
 
-Whether a functional update, `Point { ..other }`, should imply a dependency on every field
+**Functional update.** Whether `Point { ..other }` should imply a dependency on every field
 declaration of the struct. It currently reads only the base expression, pinned by a test in
 `crates/core/tests/unit/languages/rust/field_initializer_tests.rs`.
+
+**Lifetime parameters.** `struct H<'a> { v: &'a str }` produces no definition for `'a` and no edge
+from the field to it, though renaming the parameter would break the field. The fixtures do not
+annotate lifetime references, because the representation is undecided: it is unclear whether the
+symbol should be `'a` or `a`, and annotating a guess would fix the wrong answer in the baseline.
+Decide the representation first, then add the expectations.
+
+**An impl's own associated type.** `fn first(&self) -> Self::Item` inside an impl resolves to the
+trait's `type Item;` rather than the impl's own `type Item = i32`. `rust/associated_types.rs`
+follows the trait declaration and says so in a comment; the nearer alias is arguably the better
+answer.

--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -8,6 +8,14 @@
       "spurious": 0,
       "duplicates": 0
     },
+    "rust/associated_types.rs": {
+      "expected": 10,
+      "detected": 8,
+      "correct": 8,
+      "missing": 2,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "rust/closures.rs": {
       "expected": 9,
       "detected": 9,
@@ -64,6 +72,14 @@
       "spurious": 0,
       "duplicates": 0
     },
+    "rust/impl_trait.rs": {
+      "expected": 10,
+      "detected": 10,
+      "correct": 10,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "rust/imports.rs": {
       "expected": 12,
       "detected": 12,
@@ -71,6 +87,14 @@
       "missing": 0,
       "spurious": 0,
       "duplicates": 2
+    },
+    "rust/let_else.rs": {
+      "expected": 12,
+      "detected": 10,
+      "correct": 10,
+      "missing": 2,
+      "spurious": 0,
+      "duplicates": 0
     },
     "rust/loops.rs": {
       "expected": 7,
@@ -84,6 +108,14 @@
       "expected": 9,
       "detected": 9,
       "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "rust/method_chains.rs": {
+      "expected": 10,
+      "detected": 10,
+      "correct": 10,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -103,6 +135,14 @@
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
+    },
+    "rust/operator_traits.rs": {
+      "expected": 15,
+      "detected": 15,
+      "correct": 15,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 3
     },
     "rust/patterns.rs": {
       "expected": 14,
@@ -144,6 +184,30 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "rust/tuple_structs.rs": {
+      "expected": 13,
+      "detected": 11,
+      "correct": 11,
+      "missing": 2,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "rust/type_aliases.rs": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
+    "rust/use_aliases.rs": {
+      "expected": 14,
+      "detected": 14,
+      "correct": 14,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
     "rust/variables.rs": {
       "expected": 7,
       "detected": 7,
@@ -167,6 +231,14 @@
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
+    },
+    "typescript/abstract_classes.ts": {
+      "expected": 7,
+      "detected": 6,
+      "correct": 4,
+      "missing": 3,
+      "spurious": 2,
+      "duplicates": 1
     },
     "typescript/async_functions.ts": {
       "expected": 6,
@@ -240,6 +312,22 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "typescript/namespaces.ts": {
+      "expected": 10,
+      "detected": 11,
+      "correct": 10,
+      "missing": 0,
+      "spurious": 1,
+      "duplicates": 2
+    },
+    "typescript/type_aliases.ts": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
     "typescript/variables.ts": {
       "expected": 5,
       "detected": 5,
@@ -250,11 +338,11 @@
     }
   },
   "total": {
-    "expected": 293,
-    "detected": 286,
-    "correct": 280,
-    "missing": 13,
-    "spurious": 6,
-    "duplicates": 17
+    "expected": 412,
+    "detected": 399,
+    "correct": 390,
+    "missing": 22,
+    "spurious": 9,
+    "duplicates": 26
   }
 }

--- a/crates/accuracy/fixtures/rust/associated_types.rs
+++ b/crates/accuracy/fixtures/rust/associated_types.rs
@@ -1,0 +1,25 @@
+// Associated types in traits and their implementations.
+//
+// Whether `Self::Item` inside the impl should name the impl's own alias rather than the trait's
+// declaration is unsettled; these annotations follow the trait declaration.
+
+trait Container {
+    type Item;
+
+    fn first(&self) -> Self::Item; //~ depends: Container@6, Item@7
+}
+
+struct Numbers;
+
+impl Container for Numbers { //~ depends: Container@6, Numbers@12
+    type Item = i32;
+
+    fn first(&self) -> Self::Item { //~ depends: first@9, Container@6, Item@7
+        1
+    }
+}
+
+fn main() {
+    let n = Numbers; //~ depends: Numbers@12
+    let _ = n.first(); //~ depends: first@17, n@23
+}

--- a/crates/accuracy/fixtures/rust/impl_trait.rs
+++ b/crates/accuracy/fixtures/rust/impl_trait.rs
@@ -1,0 +1,25 @@
+// `impl Trait` in argument and return position.
+
+trait Shape {
+    fn area(&self) -> i32;
+}
+
+struct Square;
+
+impl Shape for Square { //~ depends: Shape@3, Square@7
+    fn area(&self) -> i32 { //~ depends: area@4
+        1
+    }
+}
+
+fn make() -> impl Shape { //~ depends: Shape@3
+    Square //~ depends: Square@7
+}
+
+fn measure(shape: impl Shape) -> i32 { //~ depends: Shape@3
+    shape.area() //~ depends: shape@19, area@10
+}
+
+fn main() {
+    let _ = measure(make()); //~ depends: measure@19, make@15
+}

--- a/crates/accuracy/fixtures/rust/let_else.rs
+++ b/crates/accuracy/fixtures/rust/let_else.rs
@@ -1,0 +1,21 @@
+// `let else`, `if let` and `while let` bindings.
+
+enum Slot {
+    Filled(i32),
+    Empty,
+}
+
+fn read(slot: Slot) -> i32 { //~ depends: Slot@3
+    let Slot::Filled(value) = slot else { //~ depends: Slot@3, Filled@4, slot@8
+        return 0;
+    };
+    value //~ depends: value@9
+}
+
+fn main() {
+    let slot = Slot::Filled(1); //~ depends: Slot@3, Filled@4
+    if let Slot::Empty = slot { //~ depends: Slot@3, Empty@5, slot@16
+        return;
+    }
+    let _ = read(slot); //~ depends: read@8, slot@16
+}

--- a/crates/accuracy/fixtures/rust/method_chains.rs
+++ b/crates/accuracy/fixtures/rust/method_chains.rs
@@ -1,0 +1,19 @@
+// Iterator chains and closures passed as arguments.
+
+struct Item {
+    weight: i32,
+}
+
+fn total(items: &[Item]) -> i32 { //~ depends: Item@3
+    items //~ depends: items@7
+        .iter()
+        .map(|item| item.weight) //~ depends: weight@4
+        .filter(|weight| *weight > 0)
+        .sum()
+}
+
+fn main() {
+    let items = vec![Item { weight: 1 }]; //~ depends: Item@3, weight@4
+    let heaviest = items.iter().map(|i| i.weight).max(); //~ depends: items@16, weight@4
+    let _ = (total(&items), heaviest); //~ depends: total@7, items@16, heaviest@17
+}

--- a/crates/accuracy/fixtures/rust/operator_traits.rs
+++ b/crates/accuracy/fixtures/rust/operator_traits.rs
@@ -1,0 +1,21 @@
+// Operator traits and indexing.
+
+struct Meters {
+    value: i32,
+}
+
+impl std::ops::Add for Meters { //~ depends: Meters@3
+    type Output = Meters; //~ depends: Meters@3
+
+    fn add(self, other: Meters) -> Meters { //~ depends: Meters@3
+        Meters { value: self.value + other.value } //~ depends: Meters@3, value@4, other@10
+    }
+}
+
+fn main() {
+    let a = Meters { value: 1 }; //~ depends: Meters@3, value@4
+    let b = Meters { value: 2 }; //~ depends: Meters@3, value@4
+    let sum = a + b; //~ depends: a@16, b@17
+    let list = [sum.value, 0]; //~ depends: sum@18, value@4
+    let _ = list[0]; //~ depends: list@19
+}

--- a/crates/accuracy/fixtures/rust/tuple_structs.rs
+++ b/crates/accuracy/fixtures/rust/tuple_structs.rs
@@ -1,0 +1,18 @@
+// Tuple structs, unit structs and their construction.
+
+struct Meters(i32);
+
+struct Marker;
+
+struct Wrapper(Meters, Marker); //~ depends: Meters@3, Marker@5
+
+fn unwrap(w: Wrapper) -> i32 { //~ depends: Wrapper@7
+    let Wrapper(meters, _) = w; //~ depends: Wrapper@7, w@9
+    let Meters(value) = meters; //~ depends: Meters@3, meters@10
+    value //~ depends: value@11
+}
+
+fn main() {
+    let w = Wrapper(Meters(1), Marker); //~ depends: Wrapper@7, Meters@3, Marker@5
+    let _ = unwrap(w); //~ depends: unwrap@9, w@16
+}

--- a/crates/accuracy/fixtures/rust/type_aliases.rs
+++ b/crates/accuracy/fixtures/rust/type_aliases.rs
@@ -1,0 +1,18 @@
+// Type aliases and their use in signatures.
+
+struct Inner {
+    v: i32,
+}
+
+type Alias = Inner; //~ depends: Inner@3
+
+type Pair = (Alias, Alias); //~ depends: Alias@7
+
+fn take(a: Alias) -> i32 { //~ depends: Alias@7
+    a.v //~ depends: a@11, v@4
+}
+
+fn main() {
+    let inner = Inner { v: 1 }; //~ depends: Inner@3, v@4
+    let _ = take(inner); //~ depends: take@11, inner@16
+}

--- a/crates/accuracy/fixtures/rust/use_aliases.rs
+++ b/crates/accuracy/fixtures/rust/use_aliases.rs
@@ -1,0 +1,25 @@
+// Import aliases, nested groups and glob imports.
+
+mod shapes {
+    pub struct Square {
+        pub side: i32,
+    }
+
+    pub struct Circle {
+        pub radius: i32,
+    }
+
+    pub fn unit() -> i32 {
+        1
+    }
+}
+
+use shapes::Square as Boxy; //~ depends: shapes@3, Square@4
+
+use shapes::{Circle, unit}; //~ depends: shapes@3, Circle@8, unit@12
+
+fn main() {
+    let b = Boxy { side: 1 }; //~ depends: Boxy@17, side@5
+    let c = Circle { radius: 2 }; //~ depends: Circle@19, radius@9
+    let _ = b.side + c.radius + unit(); //~ depends: b@22, side@5, c@23, radius@9, unit@19
+}

--- a/crates/accuracy/fixtures/typescript/abstract_classes.ts
+++ b/crates/accuracy/fixtures/typescript/abstract_classes.ts
@@ -1,0 +1,20 @@
+// Abstract classes, abstract members and their implementations.
+
+abstract class Shape {
+    abstract area(): number;
+
+    describe(): string {
+        return String(this.area()); //~ depends: area@4
+    }
+}
+
+class Square extends Shape { //~ depends: Shape@3
+    side = 1;
+
+    area(): number { //~ depends: area@4
+        return this.side * this.side; //~ depends: side@12
+    }
+}
+
+const s = new Square(); //~ depends: Square@11
+const text = s.describe(); //~ depends: describe@6, s@19

--- a/crates/accuracy/fixtures/typescript/namespaces.ts
+++ b/crates/accuracy/fixtures/typescript/namespaces.ts
@@ -1,0 +1,19 @@
+// Namespaces and qualified access into them.
+
+namespace shapes {
+    export interface Square {
+        side: number;
+    }
+
+    export function unit(): number {
+        return 1;
+    }
+}
+
+const square: shapes.Square = { side: 2 }; //~ depends: shapes@3, Square@4
+
+function area(s: shapes.Square): number { //~ depends: shapes@3, Square@4
+    return s.side * s.side; //~ depends: s@15, side@5
+}
+
+const total = area(square) + shapes.unit(); //~ depends: area@15, square@13, shapes@3, unit@8

--- a/crates/accuracy/fixtures/typescript/type_aliases.ts
+++ b/crates/accuracy/fixtures/typescript/type_aliases.ts
@@ -1,0 +1,21 @@
+// Type aliases, unions and intersections.
+
+interface Named {
+    name: string;
+}
+
+interface Aged {
+    age: number;
+}
+
+type Person = Named & Aged; //~ depends: Named@3, Aged@7
+
+type Maybe = Person | null; //~ depends: Person@11
+
+function describe(person: Person): string { //~ depends: Person@11
+    return person.name; //~ depends: person@15, name@4
+}
+
+function pick(value: Maybe): string { //~ depends: Maybe@13
+    return value === null ? "" : describe(value); //~ depends: value@19, describe@15
+}


### PR DESCRIPTION
Continues #200 by covering the constructs the fixture set still had no fixture for.

## Coverage added

**Rust:** type aliases, associated types, `impl Trait` in argument and return position, tuple and unit structs, iterator chains with closures as arguments, import aliases and nested groups, `let else` alongside `if let`, operator traits and indexing.

**TypeScript:** type aliases with unions and intersections, namespaces, abstract classes.

Fixtures **31 → 42**, expected edges **293 → 412**.

## Three more defects

| Issue | What |
| --- | --- |
| #201 | A `let` pattern registers enum path components as **bindings** |
| #202 | TypeScript abstract classes produce no definitions, and the abstract member edge runs **backwards** |
| #195 | Widened — tuple struct patterns fail the complementary half of the same pattern walk |

**#201** is the nastiest so far. For

```rust
if let S::E = s {          // L7
    return 0;
}
let S::F(v) = s else {     // L10
    return 1;
};
```

the definitions come out as

```
(10, 'S', VariableDefinition)   <-- the enum, registered as a binding
(10, 'F', VariableDefinition)   <-- the variant, registered as a binding
(10, 'v', VariableDefinition)
```

So line 10 loses both enum edges, *and* `S` on line 7 resolves to the fake binding on line 10 — an edge pointing at a line that has not been reached yet. `if let` on line 7 handles its own pattern correctly, so the defect is specific to the `let` form.

The issue also notes a contributing weakness in my own #187 change: `select_within_scope` falls back to any definition in the nearest scope when none precedes the usage. That fallback exists for hoisted items and should be restricted to them, since a `let` declared later cannot be what an earlier line names.

**#202**: `abstract class Shape` and `abstract area(): number` are distinct node kinds (`abstract_class_declaration`, `abstract_method_signature`) and neither is handled. With no definition produced, the abstract method's name falls through to identifier handling and becomes a *usage*, which resolves forward to the subclass implementation:

```
deps: [(2, 6, 'area')]     — the declaration depending on its implementation
```

That is the only edge in the file. A reader is told the abstraction depends on its implementors. Worst fixture in the set at precision 0.667 / recall 0.571.

**#195 widened** — the three pattern forms now fail in three different ways:

| Form | References the type/fields | Registers bindings |
| --- | --- | --- |
| `let P { x } = p` | no | no |
| `let Wrapper(v) = w` | no | yes |
| `let S::F(v) = s` | no | yes, *including the path components* |

All three come down to pattern nodes not being walked correctly for what they contain, so they are worth fixing together.

## Seven of twelve new fixtures score 1.000

Worth recording as evidence rather than as absence of it — these are confirmed working, not merely untested: type aliases, `impl Trait`, method chains and closure arguments, import aliases with `as` and nested groups, operator traits with indexing, TypeScript type aliases, and TypeScript namespaces bar one object-literal edge from #197.

## Three representation questions documented, not guessed

Added to the README's "Still unsettled" rather than annotated on a guess:

- **Lifetime parameters** produce no definition and no edge. `struct H<'a> { v: &'a str }` should couple the field to the parameter, but whether the symbol is `'a` or `a` is undecided, and annotating a guess would fix the wrong answer in the baseline.
- **An impl's own associated type.** `Self::Item` inside an impl resolves to the trait's `type Item;` rather than the impl's `type Item = i32`. The fixture follows the trait and says so in a comment; the nearer alias is arguably better.
- **Functional update**, carried over from #182.

## Result

```
TOTAL   expected 412  detected 399  correct 390  missing 22  spurious 9
        precision 0.977  recall 0.947
```

## Verification

- Full suite 822 passing, unchanged
- `cargo fmt --all -- --check` clean
- No production code touched; fixtures, baseline and documentation only

## Note on how this landed

This commit was first pushed directly to `main` by mistake — I stayed on `main` after merging #200 instead of branching. `main` has been force-reset to the #200 merge commit and the work re-lands here through review, as it should have from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)