### PR TITLE
fix(core): handle TypeScript abstract classes and abstract members

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -234,10 +234,10 @@
     },
     "typescript/abstract_classes.ts": {
       "expected": 7,
-      "detected": 6,
-      "correct": 4,
-      "missing": 3,
-      "spurious": 2,
+      "detected": 7,
+      "correct": 7,
+      "missing": 0,
+      "spurious": 0,
       "duplicates": 1
     },
     "typescript/async_functions.ts": {
@@ -339,10 +339,10 @@
   },
   "total": {
     "expected": 412,
-    "detected": 411,
-    "correct": 404,
-    "missing": 8,
-    "spurious": 7,
+    "detected": 412,
+    "correct": 407,
+    "missing": 5,
+    "spurious": 5,
     "duplicates": 28
   }
 }

--- a/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
@@ -15,7 +15,7 @@ const QUERIES: Queries = Queries {
             (method_definition name: (property_identifier) @method)))
     "#,
     // A base class declares by providing a body, so its methods count as declarations alongside
-    // the signatures an interface declares.
+    // the signatures an interface declares. An abstract class declares both ways at once.
     declarations: r#"
         [
           (interface_declaration
@@ -26,6 +26,12 @@ const QUERIES: Queries = Queries {
             name: (type_identifier) @type
             body: (class_body
               (method_definition name: (property_identifier) @method)))
+          (abstract_class_declaration
+            name: (type_identifier) @type
+            body: (class_body [
+              (abstract_method_signature name: (property_identifier) @method)
+              (method_definition name: (property_identifier) @method)
+            ]))
         ]
     "#,
     // `interface Extended extends Base` and `class Derived extends Base` both inherit
@@ -36,6 +42,12 @@ const QUERIES: Queries = Queries {
             name: (type_identifier) @type
             (extends_type_clause type: (type_identifier) @super))
           (class_declaration
+            name: (type_identifier) @type
+            (class_heritage [
+              (extends_clause value: (identifier) @super)
+              (implements_clause (type_identifier) @super)
+            ]))
+          (abstract_class_declaration
             name: (type_identifier) @type
             (class_heritage [
               (extends_clause value: (identifier) @super)

--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -20,7 +20,7 @@ impl NodeDefinitionExtractor for TypeScriptDefinitionExtractor {
                 .into_iter()
                 .collect(),
             "arrow_function" => self.extract_arrow_function_definition(node, scope, source),
-            "class_declaration" => self
+            "class_declaration" | "abstract_class_declaration" => self
                 .extract_class_definition(node, scope, source)
                 .into_iter()
                 .collect(),
@@ -55,7 +55,7 @@ impl NodeDefinitionExtractor for TypeScriptDefinitionExtractor {
                 .extract_property_signature(node, scope, source)
                 .into_iter()
                 .collect(),
-            "method_signature" => self
+            "method_signature" | "abstract_method_signature" => self
                 .extract_method_signature(node, scope, source)
                 .into_iter()
                 .collect(),
@@ -86,7 +86,7 @@ impl NodeDefinitionExtractor for TypeScriptDefinitionExtractor {
     fn creates_scope(&self, node: Node) -> Option<(ScopeType, Position)> {
         let scope_type = match node.kind() {
             "function_declaration" | "method_definition" | "arrow_function" => ScopeType::Function,
-            "class_declaration" => ScopeType::Class,
+            "class_declaration" | "abstract_class_declaration" => ScopeType::Class,
             "interface_declaration" => ScopeType::Interface,
             "namespace_declaration" | "internal_module" => ScopeType::Module,
             "block" => ScopeType::Block,
@@ -666,6 +666,7 @@ impl TypeScriptUsageExtractor {
                 // These are definition contexts, not usage
                 "function_declaration"
                 | "class_declaration"
+                | "abstract_class_declaration"
                 | "interface_declaration"
                 | "type_alias_declaration"
                 | "enum_declaration"
@@ -675,6 +676,7 @@ impl TypeScriptUsageExtractor {
                 | "method_definition"
                 | "property_signature"
                 | "method_signature"
+                | "abstract_method_signature"
                 | "import_specifier" => {
                     // Check if this identifier is the name being defined
                     if let Some(name_field) = parent.child_by_field_name("name") {
@@ -878,7 +880,10 @@ impl TypeScriptUsageExtractor {
         // Check if this type_identifier is directly defining something (the name being defined)
         if let Some(parent) = node.parent() {
             match parent.kind() {
-                "interface_declaration" | "type_alias_declaration" | "class_declaration" => {
+                "interface_declaration"
+                | "type_alias_declaration"
+                | "class_declaration"
+                | "abstract_class_declaration" => {
                     // Check if this is the name field (being defined) or usage within the declaration
                     if let Some(name_field) = parent.child_by_field_name("name") {
                         return node.id() == name_field.id();

--- a/crates/core/tests/unit/languages/typescript/abstract_class_tests.rs
+++ b/crates/core/tests/unit/languages/typescript/abstract_class_tests.rs
@@ -1,0 +1,83 @@
+use lintric_core::models::DefinitionType;
+use lintric_core::{analyze_content, Language};
+
+#[test]
+fn registers_an_abstract_class_as_a_class() {
+    let source = "abstract class Shape {\n    abstract area(): number;\n}\n";
+
+    assert_eq!(
+        definition_type(source, "Shape"),
+        Some(DefinitionType::ClassDefinition)
+    );
+}
+
+#[test]
+fn registers_an_abstract_method_as_a_declaration() {
+    let source = "abstract class Shape {\n    abstract area(): number;\n}\n";
+
+    assert_eq!(
+        definition_type(source, "area"),
+        Some(DefinitionType::MethodDefinition)
+    );
+}
+
+#[test]
+fn resolves_extending_an_abstract_class() {
+    let source = "abstract class Shape {\n    abstract area(): number;\n}\n\nclass Square extends Shape {\n    area(): number {\n        return 1;\n    }\n}\n";
+
+    assert!(
+        dependencies(source).contains(&(5, 1, "Shape".to_string())),
+        "{:?}",
+        dependencies(source)
+    );
+}
+
+#[test]
+fn a_concrete_method_of_an_abstract_class_calls_the_declaration() {
+    let source = "abstract class Shape {\n    abstract area(): number;\n\n    describe(): string {\n        return String(this.area());\n    }\n}\n\nclass Square extends Shape {\n    area(): number {\n        return 1;\n    }\n}\n";
+    let dependencies = dependencies(source);
+
+    assert!(
+        dependencies.contains(&(5, 2, "area".to_string())),
+        "the declaration, not a subclass: {dependencies:?}"
+    );
+    assert!(
+        !dependencies.contains(&(5, 10, "area".to_string())),
+        "{dependencies:?}"
+    );
+}
+
+#[test]
+fn an_abstract_property_is_still_a_property() {
+    let source = "abstract class Shape {\n    abstract size: number;\n\n    describe(): number {\n        return this.size;\n    }\n}\n";
+
+    assert!(
+        dependencies(source).contains(&(5, 2, "size".to_string())),
+        "{:?}",
+        dependencies(source)
+    );
+}
+
+fn definition_type(source: &str, name: &str) -> Option<DefinitionType> {
+    let (ir, _) = analyze_content(source.to_string(), Language::TypeScript).unwrap();
+
+    ir.definitions
+        .iter()
+        .find(|definition| definition.name == name)
+        .map(|definition| definition.definition_type.clone())
+}
+
+fn dependencies(source: &str) -> Vec<(usize, usize, String)> {
+    let (ir, _) = analyze_content(source.to_string(), Language::TypeScript).unwrap();
+
+    ir.dependencies
+        .iter()
+        .map(|dependency| {
+            (
+                dependency.source_line,
+                dependency.target_line,
+                dependency.symbol.clone(),
+            )
+        })
+        .collect()
+}

--- a/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
+++ b/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
@@ -120,3 +120,30 @@ fn reaches_an_interface_declaration_through_a_base_class() {
         "the nearest declaration is the base class method: {dependencies:?}"
     );
 }
+
+#[test]
+fn links_an_implementation_to_an_abstract_method_declaration() {
+    let source = "abstract class Shape {\n    abstract area(): number;\n}\n\nclass Square extends Shape {\n    area(): number {\n        return 1;\n    }\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(6, 2, "area".to_string())]
+    );
+}
+
+#[test]
+fn an_abstract_declaration_does_not_depend_on_its_implementation() {
+    let source = "abstract class Shape {\n    abstract area(): number;\n}\n\nclass Square extends Shape {\n    area(): number {\n        return 1;\n    }\n}\n";
+    let (ir, _) = analyze_content(source.to_string(), Language::TypeScript).unwrap();
+
+    assert!(
+        !ir.dependencies
+            .iter()
+            .any(|dependency| dependency.source_line == 2 && dependency.target_line == 6),
+        "{:?}",
+        ir.dependencies
+            .iter()
+            .map(|d| (d.source_line, d.target_line, &d.symbol))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/core/tests/unit/languages/typescript/mod.rs
+++ b/crates/core/tests/unit/languages/typescript/mod.rs
@@ -1,3 +1,4 @@
+pub mod abstract_class_tests;
 pub mod dependency_resolver;
 pub mod interface_implementation_tests;
 pub mod parameter_property_tests;

--- a/crates/test-generator/tests/snapshots/ts/test_generated_abstract_class_declaration.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_abstract_class_declaration.snap
@@ -24,10 +24,12 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition { position: { 1:16 to 1:25 }, name: "TestClass", definition_type: ClassDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+        Definition { position: { 1:37 to 1:43 }, name: "method", definition_type: MethodDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+    ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:16 to 1:25 }, name: "TestClass", kind: TypeIdentifier, context: None },
         Usage { position: { 1:37 to 1:43 }, name: "method", kind: FieldExpression, context: None },
     ],
     analysis_metadata: AnalysisMetadata {

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_abstract_class_declaration.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_abstract_class_declaration.snap
@@ -24,10 +24,12 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition { position: { 1:16 to 1:25 }, name: "TestClass", definition_type: ClassDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+        Definition { position: { 1:37 to 1:43 }, name: "method", definition_type: MethodDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+    ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:16 to 1:25 }, name: "TestClass", kind: TypeIdentifier, context: None },
         Usage { position: { 1:37 to 1:43 }, name: "method", kind: FieldExpression, context: None },
     ],
     analysis_metadata: AnalysisMetadata {


### PR DESCRIPTION
close: #202

## Problem

`abstract class` and `abstract` members parse as their own node kinds, and neither was handled:

```typescript
abstract class Shape {
    abstract area(): number;     // L2
}

class Square extends Shape {     // L5
    area(): number {             // L6
        return 1;
    }
}
```

```
defs: [(5, 'Square', ClassDefinition), (6, 'area', MethodDefinition)]
deps: [(2, 6, 'area')]
```

Neither `Shape` nor the abstract `area` existed as a definition. And with nothing to define it, the abstract member's name fell through to identifier handling and became a **usage**, which resolved forward to the subclass implementation — so the only edge in the file reported the declaration as depending on what implements it. A reader was told the abstraction depends on its implementors.

## Fix

Recognise `abstract_class_declaration` alongside `class_declaration` in definition extraction, scope creation and both definition-context checks, and `abstract_method_signature` alongside `method_signature`.

An abstract class declares **both ways at once** — signatures for its abstract members, bodies for its concrete ones — so the implementation queries take both from its body, and its heritage joins the supertype walk from #191.

An abstract property needs nothing: `abstract size: number` already parses as an ordinary field definition.

## Result

```
defs: [(1,'Shape',Class), (2,'area',Method), (4,'describe',Method), (9,'Square',Class), (10,'side',Property), (12,'area',Method)]
deps: [(5,2,'area',FunctionCall)        ← this.area() reaches the declaration, not a subclass
       (9,1,'Shape',TypeReference)      ← extends resolves
       (12,2,'area',TraitImplementation) ← the implementation links to the declaration
       (13,10,'side',StructFieldAccess)]
```

The backwards edge is gone.

`typescript/abstract_classes.ts` goes from the **worst fixture in the set** — precision 0.667, recall 0.571 — to **1.000 on both**. Overall 0.983/0.981 → **0.988/0.988**.

## Remaining accuracy gaps

All three are TypeScript, and all were filed from the fixture set: #197 (object literals inventing edges by name), #198 (private field references), #199 (destructuring not referencing members).

## Snapshot changes

The definitions appear and the class name stops being a usage. No dependency changes.

## Verification

- 7 new tests: abstract class registered as a class, abstract method as a declaration, `extends` on an abstract class resolving, a concrete method reaching the declaration rather than a subclass, an abstract property still being a property, an implementation linking to an abstract declaration, and the declaration *not* depending on its implementation
- Full suite 851 passing
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)