### PR TITLE
fix(core): stop member declarations becoming usages, and read shorthand properties

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -320,6 +320,14 @@
       "spurious": 0,
       "duplicates": 2
     },
+    "typescript/object_shapes.ts": {
+      "expected": 9,
+      "detected": 10,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 1,
+      "duplicates": 0
+    },
     "typescript/type_aliases.ts": {
       "expected": 9,
       "detected": 9,
@@ -338,11 +346,11 @@
     }
   },
   "total": {
-    "expected": 409,
-    "detected": 409,
-    "correct": 409,
+    "expected": 418,
+    "detected": 419,
+    "correct": 418,
     "missing": 0,
-    "spurious": 0,
+    "spurious": 1,
     "duplicates": 28
   }
 }

--- a/crates/accuracy/fixtures/typescript/object_shapes.ts
+++ b/crates/accuracy/fixtures/typescript/object_shapes.ts
@@ -1,0 +1,26 @@
+// Object literal shorthand, and members that share a name across interfaces.
+//
+// A shorthand property reads the binding it names but does not reference a declared member; see
+// "Object shapes" in the crate README.
+//
+// The two interfaces deliberately share a member name: reading `first.id` currently also links to
+// `Second.id`, which this fixture records as a known spurious edge. See #213.
+
+interface First {
+    id: string;
+}
+
+interface Second {
+    id: number;
+}
+
+const id = "x";
+const shorthand = { id }; //~ depends: id@17
+const explicit = { key: id }; //~ depends: id@17
+
+function read(first: First): string { //~ depends: First@9
+    return first.id; //~ depends: first@21, id@10
+}
+
+const value = read({ id: "y" }); //~ depends: read@21
+const both = [shorthand, explicit, value]; //~ depends: shorthand@18, explicit@19, value@25

--- a/crates/cli/tests/snapshots/test_main__debug_ir_typescript.snap
+++ b/crates/cli/tests/snapshots/test_main__debug_ir_typescript.snap
@@ -534,28 +534,6 @@ expression: out
       "context": null
     },
     {
-      "name": "x",
-      "kind": "FieldExpression",
-      "position": {
-        "start_line": 6,
-        "start_column": 5,
-        "end_line": 6,
-        "end_column": 6
-      },
-      "context": null
-    },
-    {
-      "name": "y",
-      "kind": "FieldExpression",
-      "position": {
-        "start_line": 7,
-        "start_column": 5,
-        "end_line": 7,
-        "end_column": 6
-      },
-      "context": null
-    },
-    {
       "name": "a",
       "kind": "Identifier",
       "position": {

--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -656,6 +656,9 @@ impl NodeUsageExtractor for TypeScriptUsageExtractor {
             "property_identifier" | "private_property_identifier" => {
                 self.extract_property_identifier_usage(node, scope, source)
             }
+            // `{ x }` is shorthand for `{ x: x }`, so it reads the binding. The pattern form is a
+            // different node kind and stays a binding.
+            "shorthand_property_identifier" => self.extract_identifier_usage(node, scope, source),
             _ => None,
         };
 
@@ -864,7 +867,15 @@ impl TypeScriptUsageExtractor {
                     // Property identifiers in enum bodies are definitions, not usage
                     return None;
                 }
-                "public_field_definition" | "private_field_definition" | "field_definition" => {
+                // A member declaration is a definition. Left as a usage it resolved to any
+                // same-named member of another interface, and since that member's own declaration
+                // did the same, the two invented a cycle between themselves.
+                "public_field_definition"
+                | "private_field_definition"
+                | "field_definition"
+                | "property_signature"
+                | "method_signature"
+                | "abstract_method_signature" => {
                     // Property identifiers in field definitions are definitions, not usage
                     if let Some(name_field) = parent.child_by_field_name("name") {
                         if node.id() == name_field.id() {

--- a/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_class_method_ir.snap
+++ b/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_class_method_ir.snap
@@ -280,7 +280,6 @@ IntermediateRepresentation {
         Usage { position: { 5:14 to 5:19 }, name: "value", kind: FieldExpression, context: None },
         Usage { position: { 5:23 to 5:24 }, name: "n", kind: Identifier, context: None },
         Usage { position: { 9:21 to 9:26 }, name: "value", kind: FieldExpression, context: None },
-        Usage { position: { 14:5 to 14:9 }, name: "draw", kind: FieldExpression, context: None },
         Usage { position: { 17:25 to 17:33 }, name: "Drawable", kind: TypeIdentifier, context: None },
         Usage { position: { 21:14 to 21:20 }, name: "radius", kind: FieldExpression, context: None },
         Usage { position: { 21:23 to 21:29 }, name: "radius", kind: Identifier, context: None },

--- a/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_generics_ir.snap
+++ b/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_generics_ir.snap
@@ -374,9 +374,7 @@ IntermediateRepresentation {
         Dependency { source_line: 33, target_line: 32, symbol: "users", dependency_type: VariableUse, context: Some("Identifier:33:35") },
     ],
     usage: [
-        Usage { position: { 2:5 to 2:9 }, name: "save", kind: FieldExpression, context: None },
         Usage { position: { 2:16 to 2:17 }, name: "T", kind: TypeIdentifier, context: None },
-        Usage { position: { 3:5 to 3:13 }, name: "findById", kind: FieldExpression, context: None },
         Usage { position: { 3:27 to 3:28 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 6:33 to 6:43 }, name: "Repository", kind: TypeIdentifier, context: None },
         Usage { position: { 6:44 to 6:48 }, name: "User", kind: TypeIdentifier, context: None },
@@ -393,8 +391,6 @@ IntermediateRepresentation {
         Usage { position: { 14:37 to 14:38 }, name: "u", kind: Identifier, context: Some("call_expression") },
         Usage { position: { 14:39 to 14:41 }, name: "id", kind: FieldExpression, context: None },
         Usage { position: { 14:46 to 14:48 }, name: "id", kind: Identifier, context: Some("call_expression") },
-        Usage { position: { 19:5 to 19:7 }, name: "id", kind: FieldExpression, context: None },
-        Usage { position: { 20:5 to 20:9 }, name: "name", kind: FieldExpression, context: None },
         Usage { position: { 23:33 to 23:34 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 23:39 to 23:40 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 24:12 to 24:47 }, name: "items.filter", kind: CallExpression, context: Some("call_expression") },

--- a/crates/core/tests/integration/language/typescript/snapshots/integration_tests__integration__language__typescript__hoisting_test_ir.snap
+++ b/crates/core/tests/integration/language/typescript/snapshots/integration_tests__integration__language__typescript__hoisting_test_ir.snap
@@ -237,7 +237,6 @@ IntermediateRepresentation {
         Usage { position: { 3:20 to 3:28 }, name: "helper", kind: CallExpression, context: Some("call_expression") },
         Usage { position: { 6:15 to 6:16 }, name: "x", kind: Identifier, context: None },
         Usage { position: { 17:16 to 17:27 }, name: "MyInterface", kind: TypeIdentifier, context: None },
-        Usage { position: { 21:5 to 21:10 }, name: "field", kind: FieldExpression, context: None },
         Usage { position: { 26:26 to 26:33 }, name: "MyClass", kind: Identifier, context: None },
         Usage { position: { 34:21 to 34:27 }, name: "MyType", kind: TypeIdentifier, context: None },
         Usage { position: { 42:19 to 42:25 }, name: "MyEnum", kind: Identifier, context: None },

--- a/crates/core/tests/unit/languages/typescript/object_shape_tests.rs
+++ b/crates/core/tests/unit/languages/typescript/object_shape_tests.rs
@@ -69,3 +69,51 @@ fn dependencies(source: &str) -> Vec<(usize, usize, String)> {
         })
         .collect()
 }
+
+#[test]
+fn a_shorthand_property_reads_the_binding_it_names() {
+    let source = "const x = 1;\nconst b = { x };\n";
+
+    assert!(
+        dependencies(&source).contains(&(2, 1, "x".to_string())),
+        "{:?}",
+        dependencies(&source)
+    );
+}
+
+#[test]
+fn a_shorthand_property_does_not_reference_a_member() {
+    let source = format!("{POINT}\nconst x = 1;\nconst b = {{ x }};\n");
+
+    assert!(!references_member(&source), "{:?}", dependencies(&source));
+}
+
+#[test]
+fn two_interfaces_sharing_a_member_name_do_not_depend_on_each_other() {
+    let source =
+        "interface First {\n    id: string;\n}\n\ninterface Second {\n    id: number;\n}\n";
+    let dependencies = dependencies(source);
+
+    assert!(dependencies.is_empty(), "{dependencies:?}");
+}
+
+#[test]
+fn a_method_signature_declaration_is_not_a_usage() {
+    let source =
+        "interface First {\n    run(): void;\n}\n\ninterface Second {\n    run(): void;\n}\n";
+    let dependencies = dependencies(source);
+
+    assert!(dependencies.is_empty(), "{dependencies:?}");
+}
+
+#[test]
+fn a_declared_member_is_still_reachable_through_a_value() {
+    let source =
+        "interface A {\n    id: string;\n}\n\nfunction f(a: A): string {\n    return a.id;\n}\n";
+
+    assert!(
+        dependencies(source).contains(&(6, 2, "id".to_string())),
+        "{:?}",
+        dependencies(source)
+    );
+}

--- a/crates/test-generator/tests/snapshots/ts/test_generated_abstract_class_declaration.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_abstract_class_declaration.snap
@@ -29,9 +29,7 @@ IntermediateRepresentation {
         Definition { position: { 1:37 to 1:43 }, name: "method", definition_type: MethodDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:37 to 1:43 }, name: "method", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TypeScript",
         total_lines: 1,

--- a/crates/test-generator/tests/snapshots/ts/test_generated_interface_declaration.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_interface_declaration.snap
@@ -36,10 +36,7 @@ IntermediateRepresentation {
         Definition { position: { 1:41 to 1:48 }, name: "method2", definition_type: MethodDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:27 to 1:31 }, name: "prop", kind: FieldExpression, context: None },
-        Usage { position: { 1:41 to 1:48 }, name: "method2", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TypeScript",
         total_lines: 1,

--- a/crates/test-generator/tests/snapshots/ts/test_generated_intersection_type.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_intersection_type.snap
@@ -55,10 +55,7 @@ IntermediateRepresentation {
         Definition { position: { 1:34 to 1:35 }, name: "b", definition_type: PropertyDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:18 to 1:19 }, name: "a", kind: FieldExpression, context: None },
-        Usage { position: { 1:34 to 1:35 }, name: "b", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TypeScript",
         total_lines: 1,

--- a/crates/test-generator/tests/snapshots/ts/test_generated_lookup_type.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_lookup_type.snap
@@ -48,7 +48,6 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:14 to 1:17 }, name: "key", kind: FieldExpression, context: None },
         Usage { position: { 1:44 to 1:47 }, name: "Obj", kind: TypeIdentifier, context: None },
     ],
     analysis_metadata: AnalysisMetadata {

--- a/crates/test-generator/tests/snapshots/ts/test_generated_object_type.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_object_type.snap
@@ -38,9 +38,7 @@ IntermediateRepresentation {
         Definition { position: { 1:18 to 1:23 }, name: "prop4", definition_type: PropertyDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:18 to 1:23 }, name: "prop4", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TypeScript",
         total_lines: 1,

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_abstract_class_declaration.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_abstract_class_declaration.snap
@@ -29,9 +29,7 @@ IntermediateRepresentation {
         Definition { position: { 1:37 to 1:43 }, name: "method", definition_type: MethodDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:37 to 1:43 }, name: "method", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TSX",
         total_lines: 1,

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_interface_declaration.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_interface_declaration.snap
@@ -36,10 +36,7 @@ IntermediateRepresentation {
         Definition { position: { 1:41 to 1:48 }, name: "method2", definition_type: MethodDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:27 to 1:31 }, name: "prop", kind: FieldExpression, context: None },
-        Usage { position: { 1:41 to 1:48 }, name: "method2", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TSX",
         total_lines: 1,

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_intersection_type.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_intersection_type.snap
@@ -55,10 +55,7 @@ IntermediateRepresentation {
         Definition { position: { 1:34 to 1:35 }, name: "b", definition_type: PropertyDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:18 to 1:19 }, name: "a", kind: FieldExpression, context: None },
-        Usage { position: { 1:34 to 1:35 }, name: "b", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TSX",
         total_lines: 1,

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_lookup_type.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_lookup_type.snap
@@ -48,7 +48,6 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:14 to 1:17 }, name: "key", kind: FieldExpression, context: None },
         Usage { position: { 1:44 to 1:47 }, name: "Obj", kind: TypeIdentifier, context: None },
     ],
     analysis_metadata: AnalysisMetadata {

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_object_type.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_object_type.snap
@@ -38,9 +38,7 @@ IntermediateRepresentation {
         Definition { position: { 1:18 to 1:23 }, name: "prop6", definition_type: PropertyDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
-    usage: [
-        Usage { position: { 1:18 to 1:23 }, name: "prop6", kind: FieldExpression, context: None },
-    ],
+    usage: [],
     analysis_metadata: AnalysisMetadata {
         language: "TSX",
         total_lines: 1,


### PR DESCRIPTION
close: #210
close: #211

Two defects noticed while probing #197 and now filed and fixed.

## #210 — a member declaration was a usage, inventing a cycle

```typescript
interface First {
    id: string;     // L2
}

interface Second {
    id: number;     // L6
}
```

```
deps: [(2, 6, 'id'), (6, 2, 'id')]
```

Both lines are declarations, neither references the other, and together they form a **cycle**. That is worse than an ordinary false positive: `dependency_distance_cost` charges both spans, `depth` follows the loop until the visited-set stops it, and each declaration counts as transitively reachable from the other.

Member names repeat across interfaces by design — `id`, `name`, `value`, `type` — so with *n* interfaces declaring one, this produces n×(n−1) wrong edges. The tidier the naming, the worse.

`extract_property_identifier_usage` guarded the declaration positions a property name can occupy, but omitted `property_signature`, `method_signature` and `abstract_method_signature`.

## #211 — shorthand properties read nothing

```typescript
const x = 1;          // L1
const b = { x };      // L2  →  no edges at all
```

`{ x }` is shorthand for `{ x: x }`; the value half reads the binding. The explicit form `{ k: x }` worked, because its value is an ordinary identifier. Shorthand is the idiomatic form, so this lost dependencies wherever objects are built from locals.

The pattern form is a different node kind and stays a binding, and the shorthand still does not reference a declared member — consistent with the object-shape decision in #209.

## A third defect fell out: #213

The new fixture deliberately declares `id` in two interfaces, which exposed something the old fixtures could not see:

```typescript
function read(first: First): string {
    return first.id;    // links to BOTH First.id and Second.id
}
```

Member access resolves by name against every declared member. `first` is annotated `First`, so one edge is right and the rest are invented.

Unlike #197 this cannot be fixed by declining to link — `first.id` genuinely is a member access and the correct edge is among those produced. Choosing needs the receiver's type, so it is filed as #213 with options rather than fixed here.

**It is recorded in the baseline as a known spurious edge rather than annotated away**, so precision reads 0.998 and not a rounded-up 1.000. The fixture's header says why.

## Result

```
TOTAL   expected 418  detected 419  correct 418  missing 0  spurious 1
        precision 0.998  recall 1.000
```

Snapshot changes are usages removed — 58 lines of member declarations no longer appearing as usages — plus the shorthand reads. **No edge changes**, because no existing snapshot declares the same member name twice: the fix removes latent false positives rather than current ones, which is exactly why the harness needed a fixture that does.

## Verification

- 5 new tests: shorthand reading a binding, shorthand not referencing a member, two interfaces sharing a member name producing nothing, method signatures likewise, and a declared member still reachable through a value
- Full suite 865 passing
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)