### PR TITLE
fix(core): match generic traits and interfaces to their implementations

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -64,6 +64,14 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "rust/generic_traits.rs": {
+      "expected": 10,
+      "detected": 11,
+      "correct": 10,
+      "missing": 0,
+      "spurious": 1,
+      "duplicates": 1
+    },
     "rust/generics.rs": {
       "expected": 10,
       "detected": 10,
@@ -288,6 +296,14 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "typescript/generic_interfaces.ts": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/generics.ts": {
       "expected": 12,
       "detected": 12,
@@ -346,11 +362,11 @@
     }
   },
   "total": {
-    "expected": 418,
-    "detected": 419,
-    "correct": 418,
+    "expected": 437,
+    "detected": 439,
+    "correct": 437,
     "missing": 0,
-    "spurious": 1,
-    "duplicates": 28
+    "spurious": 2,
+    "duplicates": 29
   }
 }

--- a/crates/accuracy/fixtures/rust/generic_traits.rs
+++ b/crates/accuracy/fixtures/rust/generic_traits.rs
@@ -1,0 +1,29 @@
+// Generic traits, generic supertraits and their implementations.
+//
+// `T` on line 10 is Extended's own parameter, so it produces no edge. It currently resolves to
+// Base's instead, which this fixture records as a known spurious edge. See #215.
+
+trait Base<T> {
+    fn run(&self, value: T) -> i32; //~ depends: T@6
+}
+
+trait Extended<T>: Base<T> { //~ depends: Base@6
+    fn extra(&self) -> i32;
+}
+
+struct S;
+
+impl Extended<i32> for S { //~ depends: Extended@10, S@14
+    fn run(&self, value: i32) -> i32 { //~ depends: run@7
+        value //~ depends: value@17
+    }
+
+    fn extra(&self) -> i32 { //~ depends: extra@11
+        1
+    }
+}
+
+fn main() {
+    let s = S; //~ depends: S@14
+    let _ = s.extra(); //~ depends: extra@21, s@27
+}

--- a/crates/accuracy/fixtures/typescript/generic_interfaces.ts
+++ b/crates/accuracy/fixtures/typescript/generic_interfaces.ts
@@ -1,0 +1,22 @@
+// Generic interfaces, generic inheritance and their implementations.
+
+interface Base<T> {
+    run(value: T): number; //~ depends: T@3
+}
+
+interface Extended<T> extends Base<T> { //~ depends: Base@3
+    extra(): number;
+}
+
+class Impl implements Extended<number> { //~ depends: Extended@7
+    run(value: number): number { //~ depends: run@4
+        return value; //~ depends: value@12
+    }
+
+    extra(): number { //~ depends: extra@8
+        return 1;
+    }
+}
+
+const impl = new Impl(); //~ depends: Impl@11
+const total = impl.extra(); //~ depends: extra@16, impl@21

--- a/crates/core/src/dependency_resolver/trait_implementation.rs
+++ b/crates/core/src/dependency_resolver/trait_implementation.rs
@@ -110,8 +110,8 @@ fn supertypes(
         "super",
         |type_node, super_node| {
             Some((
-                text(source_code, type_node)?,
-                text(source_code, super_node)?,
+                type_text(source_code, type_node)?,
+                type_text(source_code, super_node)?,
             ))
         },
     )?;
@@ -190,10 +190,25 @@ fn capture<'a>(query_match: &QueryMatch<'a, 'a>, index: u32) -> Option<Node<'a>>
 
 fn method(source_code: &str, type_node: Node, method_node: Node) -> Option<Method> {
     Some(Method {
-        type_name: text(source_code, type_node)?,
+        type_name: type_text(source_code, type_node)?,
         name: text(source_code, method_node)?,
         line: method_node.start_position().row + 1,
     })
+}
+
+/// The bare name of a captured type, looking through type arguments so that `Box<number>` pairs
+/// with `Box`.
+///
+/// The two grammars disagree on which field holds the name, so both are tried.
+fn type_text(source_code: &str, node: Node) -> Option<String> {
+    let named = match node.kind() {
+        "generic_type" => node
+            .child_by_field_name("type")
+            .or_else(|| node.child_by_field_name("name"))?,
+        _ => node,
+    };
+
+    text(source_code, named)
 }
 
 fn text(source_code: &str, node: Node) -> Option<String> {

--- a/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
@@ -5,7 +5,7 @@ use tree_sitter::Node;
 const QUERIES: Queries = Queries {
     implementations: r#"
         (impl_item
-          trait: (type_identifier) @type
+          trait: [(type_identifier) (generic_type)] @type
           body: (declaration_list
             (function_item name: (identifier) @method)))
     "#,
@@ -24,7 +24,7 @@ const QUERIES: Queries = Queries {
     supertypes: r#"
         (trait_item
           name: (type_identifier) @type
-          bounds: (trait_bounds (type_identifier) @super))
+          bounds: (trait_bounds [(type_identifier) (generic_type)] @super))
     "#,
 };
 

--- a/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
@@ -8,7 +8,7 @@ const QUERIES: Queries = Queries {
     implementations: r#"
         (class_declaration
           (class_heritage [
-            (implements_clause (type_identifier) @type)
+            (implements_clause [(type_identifier) (generic_type)] @type)
             (extends_clause value: (identifier) @type)
           ])
           body: (class_body
@@ -40,18 +40,18 @@ const QUERIES: Queries = Queries {
         [
           (interface_declaration
             name: (type_identifier) @type
-            (extends_type_clause type: (type_identifier) @super))
+            (extends_type_clause type: [(type_identifier) (generic_type)] @super))
           (class_declaration
             name: (type_identifier) @type
             (class_heritage [
               (extends_clause value: (identifier) @super)
-              (implements_clause (type_identifier) @super)
+              (implements_clause [(type_identifier) (generic_type)] @super)
             ]))
           (abstract_class_declaration
             name: (type_identifier) @type
             (class_heritage [
               (extends_clause value: (identifier) @super)
-              (implements_clause (type_identifier) @super)
+              (implements_clause [(type_identifier) (generic_type)] @super)
             ]))
         ]
     "#,

--- a/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_generics_ir.snap
+++ b/crates/core/tests/integration/language/typescript/dependency_resolver/snapshots/integration_tests__integration__language__typescript__dependency_resolver__typescript_integration_tests__dependency_resolver_typescript_generics_ir.snap
@@ -372,6 +372,8 @@ IntermediateRepresentation {
         Dependency { source_line: 32, target_line: 31, symbol: "user", dependency_type: VariableUse, context: Some("Identifier:32:20") },
         Dependency { source_line: 33, target_line: 23, symbol: "processItems", dependency_type: FunctionCall, context: Some("CallExpression:33:22") },
         Dependency { source_line: 33, target_line: 32, symbol: "users", dependency_type: VariableUse, context: Some("Identifier:33:35") },
+        Dependency { source_line: 9, target_line: 2, symbol: "save", dependency_type: TraitImplementation, context: Some("trait_implementation::Repository") },
+        Dependency { source_line: 13, target_line: 3, symbol: "findById", dependency_type: TraitImplementation, context: Some("trait_implementation::Repository") },
     ],
     usage: [
         Usage { position: { 2:16 to 2:17 }, name: "T", kind: TypeIdentifier, context: None },

--- a/crates/core/tests/unit/languages/rust/dependency_resolver/trait_implementation_resolver_tests.rs
+++ b/crates/core/tests/unit/languages/rust/dependency_resolver/trait_implementation_resolver_tests.rs
@@ -120,3 +120,23 @@ fn terminates_on_an_inheritance_cycle() {
         vec![(10, 2, "x".to_string())]
     );
 }
+
+#[test]
+fn links_an_implementation_of_a_generic_trait() {
+    let source = "trait Base<T> {\n    fn run(&self, v: T);\n}\n\nstruct S;\n\nimpl Base<i32> for S {\n    fn run(&self, v: i32) {}\n}\n";
+
+    assert_eq!(
+        trait_implementations(source),
+        vec![(8, 2, "run".to_string())]
+    );
+}
+
+#[test]
+fn follows_a_generic_supertrait() {
+    let source = "trait Base<T> {\n    fn run(&self, v: T);\n}\n\ntrait Extended<T>: Base<T> {}\n\nstruct S;\n\nimpl Extended<i32> for S {\n    fn run(&self, v: i32) {}\n}\n";
+
+    assert_eq!(
+        trait_implementations(source),
+        vec![(10, 2, "run".to_string())]
+    );
+}

--- a/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
+++ b/crates/core/tests/unit/languages/typescript/interface_implementation_tests.rs
@@ -147,3 +147,23 @@ fn an_abstract_declaration_does_not_depend_on_its_implementation() {
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn links_an_implementation_of_a_generic_interface() {
+    let source = "interface Box<T> {\n    get(): T;\n}\n\nclass NumberBox implements Box<number> {\n    get(): number {\n        return 1;\n    }\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(6, 2, "get".to_string())]
+    );
+}
+
+#[test]
+fn follows_a_generic_parent_interface() {
+    let source = "interface Base<T> {\n    run(v: T): void;\n}\n\ninterface Extended<T> extends Base<T> {}\n\nclass Impl implements Extended<number> {\n    run(v: number): void {}\n}\n";
+
+    assert_eq!(
+        implementations(source, Language::TypeScript),
+        vec![(8, 2, "run".to_string())]
+    );
+}


### PR DESCRIPTION
close: #212

## Problem

The implementation queries named a trait or interface as a plain identifier, so anything carrying type arguments was invisible:

```rust
trait Base<T> {
    fn run(&self, v: T);     // L2
}
trait Extended<T>: Base<T> {}

impl Extended<i32> for S {
    fn run(&self, v: i32) {} // L10  — nothing produced
}
```

Two patterns failed at once: the `trait:` field of the impl parses as `generic_type` rather than `type_identifier`, and the supertrait bound does too, so the walk added in #191 never saw it. The non-generic equivalents both worked, so this was specifically about type arguments being present.

Generic traits and interfaces are ordinary in both languages — `From<T>`, `Iterator`, `Box<T>`, any user type carrying a parameter — so every implementation of one showed no relationship to its contract.

## Fix

Accept a generic type wherever a bare name was accepted, and read the bare name back out of it. An implementation pairs with a declaration on the name alone; the type arguments do not participate.

The two grammars put that name under different fields — Rust's `generic_type` uses `type:`, TypeScript's uses `name:` — which the shared reader now handles, alongside the case it already had for `Self` in `impl<T> Holder<T>`.

Deferred twice before, in #180 and #193, to keep those changes focused.

## Result

Both languages resolve:

```
rust:       impl Extended<i32> for S  →  L10 -> L2 'run'
typescript: class NumberBox implements Box<number>  →  L6 -> L2 'get'
```

Two snapshot edges appear, none removed: methods of a class implementing a generic interface now link to their declarations.

## Adding the fixtures exposed #215

```rust
trait A<T> { fn a(&self, v: T); }   // T declared L1
trait B<T> { fn b(&self, v: T); }   // T declared L5
fn f<T>(v: T) -> i32 { 0 }          // T declared L9
```

```
(2, 1, 'T')   correct
(5, 1, 'T')   wrong — B's own declaration, resolving to A's parameter
(6, 1, 'T')   wrong — should be T@5
(9, 1, 'T')   wrong — should be T@9, which is a self-edge and so no edge
```

Type parameters resolve by name across the whole file, ignoring scope, and their declarations are emitted as usages so declarations resolve to each other. `T` being the most common type parameter name there is, any file with two generic items has every reference but the first pointing at the wrong declaration.

Filed as #215 rather than fixed here — it is a resolution defect, not a query one. **Recorded in the baseline as a known spurious edge**, with the reason in the fixture header, so precision reads 0.995 rather than being annotated away.

## Result

```
TOTAL   expected 437  detected 439  correct 437  missing 0  spurious 2
        precision 0.995  recall 1.000
```

The two spurious edges are the known ones: #213 and #215.

## Verification

- 4 new tests: a generic trait implementation, a generic supertrait, a generic interface implementation, and a generic parent interface
- Full suite 869 passing
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)