### PR TITLE
fix(core): stop a type parameter declaration depending on another of the same name

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -65,11 +65,11 @@
       "duplicates": 1
     },
     "rust/generic_traits.rs": {
-      "expected": 10,
-      "detected": 11,
-      "correct": 10,
+      "expected": 12,
+      "detected": 14,
+      "correct": 12,
       "missing": 0,
-      "spurious": 1,
+      "spurious": 2,
       "duplicates": 1
     },
     "rust/generics.rs": {
@@ -362,11 +362,11 @@
     }
   },
   "total": {
-    "expected": 437,
-    "detected": 439,
-    "correct": 437,
+    "expected": 439,
+    "detected": 442,
+    "correct": 439,
     "missing": 0,
-    "spurious": 2,
+    "spurious": 3,
     "duplicates": 29
   }
 }

--- a/crates/accuracy/fixtures/rust/generic_traits.rs
+++ b/crates/accuracy/fixtures/rust/generic_traits.rs
@@ -1,7 +1,7 @@
 // Generic traits, generic supertraits and their implementations.
 //
-// `T` on line 10 is Extended's own parameter, so it produces no edge. It currently resolves to
-// Base's instead, which this fixture records as a known spurious edge. See #215.
+// `T` on lines 10 and 27 is the local parameter, so those references produce no edge. They
+// currently resolve to Base's instead, recorded here as known spurious edges. See #215.
 
 trait Base<T> {
     fn run(&self, value: T) -> i32; //~ depends: T@6
@@ -23,7 +23,13 @@ impl Extended<i32> for S { //~ depends: Extended@10, S@14
     }
 }
 
+// A third `T`, on a generic function: both references are to the local parameter.
+fn identity<T>(value: T) -> T {
+    value //~ depends: value@27
+}
+
 fn main() {
     let s = S; //~ depends: S@14
-    let _ = s.extra(); //~ depends: extra@21, s@27
+    let _ = s.extra(); //~ depends: extra@21, s@32
+    let _ = identity(1); //~ depends: identity@27
 }

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -923,6 +923,14 @@ impl RustUsageExtractor {
                 }
                 "closure_parameters" => return true,
                 "type_parameters" => return true,
+                // `T` in `<T>` sits under a `type_parameter`, so the list above never sees it and
+                // the declaration was being collected as a usage
+                "type_parameter" => {
+                    if let Some(name_field) = parent.child_by_field_name("name") {
+                        return node.id() == name_field.id();
+                    }
+                    return true;
+                }
                 "lifetime" => return true,
                 "trait_bounds" => return false,
                 "where_clause" => return true,

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_advanced_generics_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_advanced_generics_ir.snap
@@ -263,7 +263,6 @@ IntermediateRepresentation {
     usage: [
         Usage { position: { 2:24 to 2:28 }, name: "Clone", kind: TypeIdentifier, context: Some("self_type") },
         Usage { position: { 6:26 to 6:32 }, name: "String", kind: TypeIdentifier, context: None },
-        Usage { position: { 9:17 to 9:18 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 9:20 to 9:25 }, name: "Clone", kind: TypeIdentifier, context: None },
         Usage { position: { 9:28 to 9:35 }, name: "Display", kind: TypeIdentifier, context: None },
         Usage { position: { 9:44 to 9:45 }, name: "T", kind: TypeIdentifier, context: None },

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_async_dependencies_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_async_dependencies_ir.snap
@@ -246,7 +246,6 @@ IntermediateRepresentation {
         Usage { position: { 9:5 to 9:12 }, name: "println", kind: Identifier, context: None },
         Usage { position: { 9:31 to 9:35 }, name: "data", kind: Identifier, context: None },
         Usage { position: { 10:5 to 10:11 }, name: "Ok", kind: CallExpression, context: Some("call_expression") },
-        Usage { position: { 13:15 to 13:16 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 13:18 to 13:24 }, name: "Future", kind: TypeIdentifier, context: None },
         Usage { position: { 13:25 to 13:31 }, name: "Output", kind: TypeIdentifier, context: None },
         Usage { position: { 13:47 to 13:48 }, name: "F", kind: TypeIdentifier, context: None },

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_complex_trait_hierarchy_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_complex_trait_hierarchy_ir.snap
@@ -330,7 +330,6 @@ IntermediateRepresentation {
         Usage { position: { 25:6 to 25:12 }, name: "Mammal", kind: TypeIdentifier, context: None },
         Usage { position: { 25:17 to 25:20 }, name: "Dog", kind: TypeIdentifier, context: None },
         Usage { position: { 27:10 to 27:18 }, name: "fur", kind: FieldExpression, context: Some("field_expression") },
-        Usage { position: { 31:22 to 31:23 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 31:25 to 31:31 }, name: "Mammal", kind: TypeIdentifier, context: None },
         Usage { position: { 31:42 to 31:43 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 32:5 to 32:12 }, name: "println", kind: Identifier, context: None },

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_generic_resolution_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_generic_resolution_ir.snap
@@ -199,7 +199,6 @@ IntermediateRepresentation {
     ],
     dependencies: [
         Dependency { source_line: 2, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:2:11") },
-        Dependency { source_line: 5, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:5:6") },
         Dependency { source_line: 5, target_line: 1, symbol: "Container", dependency_type: TypeReference, context: Some("TypeIdentifier:5:9") },
         Dependency { source_line: 5, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:5:19") },
         Dependency { source_line: 6, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:6:18") },
@@ -209,7 +208,6 @@ IntermediateRepresentation {
         Dependency { source_line: 7, target_line: 6, symbol: "item", dependency_type: VariableUse, context: Some("Identifier:7:21") },
         Dependency { source_line: 10, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:10:23") },
         Dependency { source_line: 11, target_line: 2, symbol: "item", dependency_type: StructFieldAccess, context: Some("FieldExpression:11:10") },
-        Dependency { source_line: 15, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:15:12") },
         Dependency { source_line: 15, target_line: 1, symbol: "Container", dependency_type: TypeReference, context: Some("TypeIdentifier:15:34") },
         Dependency { source_line: 15, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:15:44") },
         Dependency { source_line: 15, target_line: 1, symbol: "T", dependency_type: TypeReference, context: Some("TypeIdentifier:15:51") },
@@ -222,9 +220,7 @@ IntermediateRepresentation {
         Dependency { source_line: 22, target_line: 21, symbol: "value", dependency_type: VariableUse, context: Some("Identifier:22:20") },
     ],
     usage: [
-        Usage { position: { 1:18 to 1:19 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 2:11 to 2:12 }, name: "T", kind: TypeIdentifier, context: None },
-        Usage { position: { 5:6 to 5:7 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 5:9 to 5:18 }, name: "Container", kind: TypeIdentifier, context: None },
         Usage { position: { 5:19 to 5:20 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 6:18 to 6:19 }, name: "T", kind: TypeIdentifier, context: None },
@@ -235,7 +231,6 @@ IntermediateRepresentation {
         Usage { position: { 7:21 to 7:25 }, name: "item", kind: Identifier, context: None },
         Usage { position: { 10:23 to 10:24 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 11:10 to 11:19 }, name: "item", kind: FieldExpression, context: Some("field_expression") },
-        Usage { position: { 15:12 to 15:13 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 15:15 to 15:20 }, name: "Clone", kind: TypeIdentifier, context: None },
         Usage { position: { 15:34 to 15:43 }, name: "Container", kind: TypeIdentifier, context: None },
         Usage { position: { 15:44 to 15:45 }, name: "T", kind: TypeIdentifier, context: None },

--- a/crates/core/tests/unit/languages/rust/self_type_tests.rs
+++ b/crates/core/tests/unit/languages/rust/self_type_tests.rs
@@ -105,3 +105,19 @@ fn dependencies(source: &str) -> Vec<(usize, usize, String)> {
         })
         .collect()
 }
+
+#[test]
+fn a_type_parameter_declaration_does_not_depend_on_another_of_the_same_name() {
+    // `trait B<T>` declares its own parameter. Left as a usage it resolved to A's, so one
+    // declaration depended on another.
+    let source =
+        "trait A<T> {\n    fn a(&self, v: T);\n}\n\ntrait B<T> {\n    fn b(&self, v: T);\n}\n";
+    let dependencies = dependencies(source);
+
+    assert!(
+        !dependencies
+            .iter()
+            .any(|(from, _, symbol)| *from == 5 && symbol == "T"),
+        "line 5 declares T and references nothing: {dependencies:?}"
+    );
+}

--- a/crates/test-generator/tests/snapshots/rust/test_generated_bounded_type.snap
+++ b/crates/test-generator/tests/snapshots/rust/test_generated_bounded_type.snap
@@ -55,7 +55,6 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:9 to 1:10 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 1:12 to 1:17 }, name: "Clone", kind: TypeIdentifier, context: None },
         Usage { position: { 1:20 to 1:24 }, name: "Send", kind: TypeIdentifier, context: None },
         Usage { position: { 1:29 to 1:30 }, name: "T", kind: TypeIdentifier, context: None },

--- a/crates/test-generator/tests/snapshots/rust/test_generated_higher_ranked_trait_bound.snap
+++ b/crates/test-generator/tests/snapshots/rust/test_generated_higher_ranked_trait_bound.snap
@@ -67,7 +67,6 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:13 to 1:14 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 1:19 to 1:20 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 1:28 to 1:29 }, name: "F", kind: TypeIdentifier, context: None },
         Usage { position: { 1:39 to 1:41 }, name: "Fn", kind: TypeIdentifier, context: None },

--- a/crates/test-generator/tests/snapshots/rust/test_generated_removed_trait_bound.snap
+++ b/crates/test-generator/tests/snapshots/rust/test_generated_removed_trait_bound.snap
@@ -32,7 +32,6 @@ IntermediateRepresentation {
     ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:13 to 1:14 }, name: "T", kind: TypeIdentifier, context: None },
         Usage { position: { 1:19 to 1:20 }, name: "T", kind: TypeIdentifier, context: None },
     ],
     analysis_metadata: AnalysisMetadata {


### PR DESCRIPTION
Partial fix for #215 — the declaration half. **Does not close the issue**; the reference half is diagnosed in a comment there rather than attempted here.

## What is fixed

```rust
trait A<T> {
    fn a(&self, v: T);
}

trait B<T> {          // L5 — depended on A's parameter at L1
    fn b(&self, v: T);
}
```

`T` in `<T>` sits under a `type_parameter` node, and `is_identifier_in_definition_context` looked only one level up at `type_parameters`. So the declaration was collected as a usage, and resolved to the first `T` in the file — one generic item's declaration depending on another's.

```
before: (5, 1, 'T')
after:  —
```

Two snapshot edges are removed, none added.

## What is not fixed, and why I stopped

References still land on the first declaration: `(6, 1, 'T')` should be `T@5`, and `(9, 1, 'T')` should be a self-edge and therefore nothing.

I tried the obvious fix — pointing the `TypeIdentifier` branch at `select_nearest_in_scope_chain`, which resolves this correctly in isolation — and it changed **nothing**, because `resolve_shadowed_symbol` runs earlier in `resolve_single_dependency` and returns on success, so that branch never sees these usages. The edit is reverted rather than left as dead code.

Underneath that sits a second problem, in `ResolutionCandidate::calculate_priority_score`:

```rust
let distance_weight = 1.0 / (scope_distance as f64 + 1.0);      // at most 1.0
let shadowing_weight = 100.0 / (shadowing_level as f64 + 1.0);  // at most 100.0
```

`shadowing_level` is not a shadowing level — `resolve_name_candidates` passes the **index within the scope's symbol list**. Weighted at 100 against a distance weight of at most 1, a candidate at index 0 in a distant scope beats one at index 1 in the enclosing scope.

Fixing that is a one-line semantic change that will move edges far beyond type parameters, and it belongs in a change of its own with the fixtures watched. Doing it inside this one would have made a two-line extraction fix into an unreviewable resolver change. The full diagnosis, including a suggested order, is [on the issue](https://github.com/unhappychoice/lintric/issues/215#issuecomment-5078849242).

## What is pinned instead

`rust/generic_traits.rs` now declares `T` on three items — two traits and a generic function — and **records the two remaining wrong edges as known spurious** rather than annotating them away:

```
spurious: L10 -> L6 "T"
spurious: L27 -> L6 "T"
```

So the harness reports precision 0.993, not a rounded-up 1.000, and a future fix has a target to move.

```
TOTAL   expected 439  detected 442  correct 439  missing 0  spurious 3
        precision 0.993  recall 1.000
```

The third spurious edge is #213.

## Verification

- 1 new test asserting a type parameter declaration produces no edge to another of the same name, which is the part that is actually fixed
- Full suite 870 passing
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)