### PR TITLE
refactor(core): drop the resolver state nothing reads

### DIFF
--- a/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
@@ -1,12 +1,8 @@
 use super::nested_scope_resolver::ScopeUtilities;
-use super::{
-    AssociatedTypeResolver, GenericTypeResolver, LifetimeResolver, MethodResolver, ModuleResolver,
-    NestedScopeResolver, TraitBound,
-};
 use crate::dependency_resolver::DependencyResolverTrait;
 use crate::models::{
     scope::{CodeAnalysisContext, SymbolTable},
-    Definition, Dependency, ScopeId, ScopeType, Type, Usage, UsageKind,
+    Definition, Dependency, ScopeId, ScopeType, Usage, UsageKind,
 };
 use tree_sitter::Node;
 
@@ -14,32 +10,11 @@ use tree_sitter::Node;
 /// including generics, lifetimes, traits, and Rust-specific language features
 pub struct RustDependencyResolver {
     symbol_table: SymbolTable,
-    nested_scope_resolver: NestedScopeResolver,
-    module_resolver: ModuleResolver,
-    pub method_resolver: MethodResolver,
-    generic_type_resolver: GenericTypeResolver,
-    associated_type_resolver: AssociatedTypeResolver,
-    lifetime_resolver: LifetimeResolver,
 }
 
 impl RustDependencyResolver {
     pub fn new(symbol_table: SymbolTable) -> Self {
-        let nested_scope_resolver = NestedScopeResolver::new(symbol_table.scopes.clone());
-        let module_resolver = ModuleResolver::new();
-        let method_resolver = MethodResolver::new();
-        let generic_type_resolver = GenericTypeResolver::new();
-        let associated_type_resolver = AssociatedTypeResolver::new();
-        let lifetime_resolver = LifetimeResolver::new();
-
-        Self {
-            symbol_table,
-            nested_scope_resolver,
-            module_resolver,
-            method_resolver,
-            generic_type_resolver,
-            associated_type_resolver,
-            lifetime_resolver,
-        }
+        Self { symbol_table }
     }
 
     pub fn new_from_context(context: CodeAnalysisContext) -> Self {
@@ -57,54 +32,6 @@ impl RustDependencyResolver {
         }
 
         Self::new(symbol_table)
-    }
-
-    pub fn get_module_resolver(&self) -> &ModuleResolver {
-        &self.module_resolver
-    }
-
-    pub fn get_module_resolver_mut(&mut self) -> &mut ModuleResolver {
-        &mut self.module_resolver
-    }
-
-    pub fn get_method_resolver(&self) -> &MethodResolver {
-        &self.method_resolver
-    }
-
-    pub fn get_generic_type_resolver(&self) -> &GenericTypeResolver {
-        &self.generic_type_resolver
-    }
-
-    pub fn get_generic_type_resolver_mut(&mut self) -> &mut GenericTypeResolver {
-        &mut self.generic_type_resolver
-    }
-
-    pub fn get_associated_type_resolver(&self) -> &AssociatedTypeResolver {
-        &self.associated_type_resolver
-    }
-
-    pub fn get_lifetime_resolver(&self) -> &LifetimeResolver {
-        &self.lifetime_resolver
-    }
-
-    /// Validate trait bounds for a given type
-    pub fn validate_trait_bounds(
-        &self,
-        type_arg: &Type,
-        bounds: &[TraitBound],
-        _scope_id: ScopeId,
-    ) -> bool {
-        self.generic_type_resolver
-            .constraint_solver
-            .check_trait_bounds(std::slice::from_ref(type_arg), bounds)
-    }
-
-    /// Get nested scope information using nested scope resolver
-    pub fn analyze_nested_scopes(&self, scope_id: ScopeId) -> bool {
-        self.nested_scope_resolver
-            .scope_tree
-            .get_scope(scope_id)
-            .is_some()
     }
 
     /// Calculate scope distance between two scopes


### PR DESCRIPTION
Second step on #125, following #219. **Still does not close it** — see below for what remains and why it is a judgement call rather than a cleanup.

## What #219 revealed

Deleting the unreachable path left every specialized resolver in `RustDependencyResolver` with **zero call sites**:

```
self.module_resolver           only inside its own getters
self.method_resolver           only inside its own getter
self.generic_type_resolver     only inside its getters and validate_trait_bounds
self.associated_type_resolver  only inside its own getter
self.lifetime_resolver         only inside its own getter
self.nested_scope_resolver     only inside analyze_nested_scopes
```

And the accessors exposing them had no callers anywhere, tests included. They were state kept alive by the methods that read them, and nothing else.

## What goes

- the five resolver fields and their seven getters
- `validate_trait_bounds`, whose only user was itself
- `analyze_nested_scopes`, unused

`calculate_scope_distance` stays — a test exercises it. Worth noting what it turned out to be: it *appeared* to delegate to `nested_scope_resolver`, but reads `self.symbol_table.scopes` directly, so the sixth field went with the others.

The struct now holds only the symbol table it actually uses:

```rust
pub struct RustDependencyResolver {
    symbol_table: SymbolTable,
}
```

`ScopeUtilities` is genuinely used and untouched.

## Behaviour unchanged

```
accuracy matches the recorded baseline
875 tests passing
no snapshot moves
```

## What remains on #125, and why I stopped here

The resolver **modules** are still present. On the Rust side their only remaining production references are `mod.rs` re-exports:

```
pub use associated_type_resolver::AssociatedTypeResolver;
pub use lifetime_resolver::LifetimeResolver;
pub use module_resolver::{ImportResolver, ModuleResolver, VisibilityChecker};
pub use nested_scope_resolver::{ClosureAnalyzer, NestedScopeResolver, ScopeChainWalker};
```

So they are **tested but unwired**: real logic, covered by unit tests, reachable from nothing that runs. Roughly 1,800 lines across `module_resolver`, `method_resolver`, `nested_scope_resolver`, `associated_type_resolver`, `lifetime_resolver`, `type_system`, `constraint_solver`, `trait_database` and `impl_collector`.

Deleting them is not cleanup — it discards intended functionality. #95 asks for comprehensive scope-aware resolution, and much of what those modules contain is what that would be built from. Whether they are a head start or a liability is a product call, so I have left them and said so rather than deciding it.

If they are wanted, wiring them in is the work #95 describes. If they are not, deleting them is a large but mechanical change the fixtures can verify. Either way it should be an explicit decision.

## Verification

- `cargo run -p lintric-accuracy -- --check` matches
- Full suite 875 passing, zero snapshot changes
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)