### PR TITLE
feat(core): locate Rust declarations by query instead of by hand

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ For detailed information on debugging methods, such as displaying AST and IR, pl
 
 If you are implementing dependency collection for a new language feature, please refer to the [Implementing New Language Features documentation](docs/development/implementing.md).
 
+Declarations are located by tree-sitter queries rather than hand-written traversal where their shape is enough to identify them; see [Locating declarations with queries](docs/development/queries.md).
+
 ## Commit Message Guidelines
 
 We follow a [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/) for our commit messages.

--- a/crates/core/queries/rust/definitions.scm
+++ b/crates/core/queries/rust/definitions.scm
@@ -1,0 +1,27 @@
+; Rust declarations whose name is simply the `name:` field of the item.
+;
+; Each capture names what the declaration is; the mapping table beside this file turns that into a
+; DefinitionType. Declarations needing more than the node's shape to classify — a `function_item`,
+; which is a method inside an impl and a function outside — stay in the extractor.
+
+(struct_item name: (type_identifier) @definition.struct)
+(union_item name: (type_identifier) @definition.struct)
+
+(enum_item name: (type_identifier) @definition.enum)
+(enum_variant name: (identifier) @definition.enum_variant)
+
+(trait_item name: (type_identifier) @definition.type)
+(type_item name: (type_identifier) @definition.type)
+(associated_type name: (type_identifier) @definition.type)
+(type_parameter name: (type_identifier) @definition.type)
+
+(mod_item name: (identifier) @definition.module)
+
+(const_item name: (identifier) @definition.const)
+(static_item name: (identifier) @definition.variable)
+
+(function_signature_item name: (identifier) @definition.function)
+
+(field_declaration name: (field_identifier) @definition.field)
+
+(macro_definition name: (identifier) @definition.macro)

--- a/crates/core/src/languages/language_factory.rs
+++ b/crates/core/src/languages/language_factory.rs
@@ -16,7 +16,7 @@ pub fn analyze_code_unified<'a>(
 
     match language {
         Language::Rust => {
-            let def_extractor = RustDefinitionExtractor;
+            let def_extractor = RustDefinitionExtractor::new(source_code, root_node);
             let usage_extractor = RustUsageExtractor;
             Ok(traverser.traverse(root_node, source_code, &def_extractor, &usage_extractor))
         }

--- a/crates/core/src/languages/rust/definition_queries.rs
+++ b/crates/core/src/languages/rust/definition_queries.rs
@@ -1,0 +1,33 @@
+use crate::models::DefinitionType;
+use crate::query::{self, Roles};
+use tree_sitter::Node;
+
+/// Declarations located by query rather than by hand-written traversal.
+const QUERY: &str = include_str!("../../../queries/rust/definitions.scm");
+
+/// What each capture in that file means.
+const ROLES: [(&str, DefinitionType); 10] = [
+    ("definition.struct", DefinitionType::StructDefinition),
+    ("definition.enum", DefinitionType::EnumDefinition),
+    (
+        "definition.enum_variant",
+        DefinitionType::EnumVariantDefinition,
+    ),
+    ("definition.type", DefinitionType::TypeDefinition),
+    ("definition.module", DefinitionType::ModuleDefinition),
+    ("definition.const", DefinitionType::ConstDefinition),
+    ("definition.variable", DefinitionType::VariableDefinition),
+    ("definition.function", DefinitionType::FunctionDefinition),
+    ("definition.field", DefinitionType::StructFieldDefinition),
+    ("definition.macro", DefinitionType::MacroDefinition),
+];
+
+/// Run the declaration query over a file, giving the kind of declaration each captured name node
+/// introduces.
+///
+/// A malformed query is a bug in the file beside this one rather than something a caller can act
+/// on, so an empty map is returned and analysis continues with whatever the extractor still handles
+/// itself.
+pub fn declared_types(source_code: &str, root_node: Node) -> Roles<DefinitionType> {
+    query::capture_roles(QUERY, source_code, root_node, &ROLES).unwrap_or_default()
+}

--- a/crates/core/src/languages/rust/mod.rs
+++ b/crates/core/src/languages/rust/mod.rs
@@ -1,3 +1,4 @@
+pub mod definition_queries;
 pub mod dependency_resolver;
 pub mod format_string;
 pub mod formatter;

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -5,12 +5,53 @@ use crate::models::{
     ast_traverser::{NodeDefinitionExtractor, NodeUsageExtractor},
     Definition, DefinitionType, Position, ScopeId, ScopeType, Usage, UsageKind,
 };
+use crate::query::Roles;
 
 /// Rust-specific definition extractor
-pub struct RustDefinitionExtractor;
+///
+/// Declarations whose shape alone identifies them are located by
+/// `queries/rust/definitions.scm`; the arms below handle the rest, where classifying needs more
+/// than the node — a `function_item` is a method inside an impl and a function outside it.
+pub struct RustDefinitionExtractor {
+    declared_types: Roles<DefinitionType>,
+}
+
+impl RustDefinitionExtractor {
+    pub fn new(source_code: &str, root_node: Node) -> Self {
+        Self {
+            declared_types: super::definition_queries::declared_types(source_code, root_node),
+        }
+    }
+
+    /// The declaration this node introduces, if the query located one here.
+    fn queried_definition(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Definition> {
+        let Some(definition_type) = self.declared_types.get(&node.id()) else {
+            return vec![];
+        };
+        let Ok(name) = node.utf8_text(source.as_bytes()) else {
+            return vec![];
+        };
+
+        vec![Definition {
+            name: name.to_string(),
+            definition_type: definition_type.clone(),
+            position: Position::from_node(&node),
+            scope_id: Some(scope),
+            accessibility: None,
+            is_hoisted: Some(false),
+        }]
+    }
+}
 
 impl NodeDefinitionExtractor for RustDefinitionExtractor {
     fn extract_definition(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Definition> {
+        // The query is the primary source; the arms below are the exceptions it cannot express.
+        // Asking it first also keeps a name node from being swallowed by the `identifier` arm.
+        let queried = self.queried_definition(node, scope, source);
+        if !queried.is_empty() {
+            return queried;
+        }
+
         match node.kind() {
             // Scope-creating items: definitions go to PARENT scope
             "function_item" => {
@@ -25,73 +66,17 @@ impl NodeDefinitionExtractor for RustDefinitionExtractor {
                         .collect()
                 }
             }
-            "struct_item" => self
-                .extract_struct_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "union_item" => self
-                .extract_union_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "enum_item" => self
-                .extract_enum_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "enum_variant" => self
-                .extract_enum_variant_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "trait_item" => self
-                .extract_trait_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "impl_item" => vec![], // impl items don't create definitions themselves
-            "mod_item" => self
-                .extract_module_definition(node, scope, source)
-                .into_iter()
-                .collect(),
 
             // Non-scope-creating items: definitions go to CURRENT scope
             "let_declaration" => self.extract_let_definition(node, scope, source),
-            "const_item" => self
-                .extract_const_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "static_item" => self
-                .extract_static_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "type_item" => self
-                .extract_type_alias_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "parameter" => self
                 .extract_parameter_definition(node, scope, source)
                 .into_iter()
                 .collect(),
-            "function_signature_item" => self
-                .extract_function_signature_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "associated_type" => self
-                .extract_associated_type_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "field_declaration" => self
-                .extract_field_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "use_declaration" => self.extract_import_definition(node, scope, source),
-            "macro_definition" => self
-                .extract_macro_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "metavariable" => self
                 .extract_metavariable_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "type_parameter" => self
-                .extract_type_parameter_definition(node, scope, source)
                 .into_iter()
                 .collect(),
             "constrained_type_parameter" => self
@@ -228,82 +213,6 @@ impl RustDefinitionExtractor {
             .collect()
     }
 
-    fn extract_function_signature_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::FunctionDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_associated_type_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::TypeDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_trait_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::TypeDefinition, // Match old implementation
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_field_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::StructFieldDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
     fn extract_import_definition(
         &self,
         node: Node,
@@ -391,25 +300,6 @@ impl RustDefinitionExtractor {
         definitions
     }
 
-    fn extract_macro_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::MacroDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
     fn extract_metavariable_definition(
         &self,
         node: Node,
@@ -431,25 +321,6 @@ impl RustDefinitionExtractor {
         } else {
             None
         }
-    }
-
-    fn extract_type_parameter_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::TypeDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
     }
 
     fn extract_constrained_type_parameter_definition(
@@ -475,82 +346,6 @@ impl RustDefinitionExtractor {
         None
     }
 
-    fn extract_struct_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::StructDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_union_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::StructDefinition, // Unions are similar to structs in Rust
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_enum_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::EnumDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_enum_variant_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::EnumVariantDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
     #[allow(dead_code)]
     fn extract_impl_definition(
         &self,
@@ -566,25 +361,6 @@ impl RustDefinitionExtractor {
             name: format!("impl {}", type_text),
             definition_type: DefinitionType::ClassDefinition,
             position: Position::from_node(&type_node),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_module_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::ModuleDefinition,
-            position: Position::from_node(&name),
             scope_id: Some(scope),
             accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
             is_hoisted: Some(false),
@@ -611,63 +387,6 @@ impl RustDefinitionExtractor {
         Some(Definition {
             name: name_text.to_string(),
             definition_type: DefinitionType::VariableDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_const_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::ConstDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_static_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::VariableDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_type_alias_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: name_text.to_string(),
-            definition_type: DefinitionType::TypeDefinition,
             position: Position::from_node(&name),
             scope_id: Some(scope),
             accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod file_parser;
 pub mod languages;
 pub mod metric_calculator;
 pub mod models;
+pub mod query;
 
 use serde::Serialize;
 

--- a/crates/core/src/query/mod.rs
+++ b/crates/core/src/query/mod.rs
@@ -1,0 +1,56 @@
+//! Running tree-sitter queries and turning their captures into roles.
+//!
+//! A query file states which nodes matter and what each one is, using capture names. The language
+//! supplies a table mapping those names to whatever it wants to know — a `DefinitionType`, say —
+//! and this module returns the answer keyed by node, so an extractor can ask about the node it is
+//! looking at without repeating the pattern in Rust.
+
+use std::collections::HashMap;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Node, Query, QueryCursor};
+
+/// The role each captured node plays, keyed by node id.
+pub type Roles<T> = HashMap<usize, T>;
+
+/// Run a query and label every captured node with the role its capture name maps to.
+///
+/// Capture names absent from `mapping` are ignored, so a query may capture nodes for other
+/// purposes without disturbing this one.
+pub fn capture_roles<T: Clone>(
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+    mapping: &[(&str, T)],
+) -> Result<Roles<T>, String> {
+    let language = &*root_node.language();
+    let query = Query::new(language, query_source)
+        .map_err(|error| format!("Failed to create query: {error}"))?;
+
+    let roles_by_index = indexed_roles(&query, mapping);
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
+    let mut roles = Roles::new();
+
+    while let Some(query_match) = matches.next() {
+        for capture in query_match.captures {
+            if let Some(role) = roles_by_index.get(&capture.index) {
+                roles.insert(capture.node.id(), role.clone());
+            }
+        }
+    }
+
+    Ok(roles)
+}
+
+/// Resolve the mapping's capture names to the indices the query assigned them, once, so the match
+/// loop compares integers rather than strings.
+fn indexed_roles<T: Clone>(query: &Query, mapping: &[(&str, T)]) -> HashMap<u32, T> {
+    mapping
+        .iter()
+        .filter_map(|(name, role)| {
+            query
+                .capture_index_for_name(name)
+                .map(|index| (index, role.clone()))
+        })
+        .collect()
+}

--- a/crates/core/tests/unit/mod.rs
+++ b/crates/core/tests/unit/mod.rs
@@ -1,3 +1,4 @@
 pub mod languages;
 pub mod metric_calculator;
 pub mod models;
+pub mod query;

--- a/crates/core/tests/unit/query/capture_roles_tests.rs
+++ b/crates/core/tests/unit/query/capture_roles_tests.rs
@@ -1,0 +1,107 @@
+use lintric_core::query::capture_roles;
+use lintric_core::{analyze_content, Language};
+
+/// Roles are compared by identity in these tests, so a plain marker type is enough.
+#[derive(Clone, Debug, PartialEq)]
+enum Role {
+    Type,
+    Field,
+}
+
+#[test]
+fn labels_a_captured_node_with_the_role_its_capture_name_maps_to() {
+    let roles = roles_for(
+        "struct P {\n    x: i32,\n}\n",
+        "(struct_item name: (type_identifier) @kind.type)\n(field_declaration name: (field_identifier) @kind.field)",
+        &[("kind.type", Role::Type), ("kind.field", Role::Field)],
+    );
+
+    assert_eq!(
+        roles,
+        vec![
+            ("P".to_string(), Role::Type),
+            ("x".to_string(), Role::Field)
+        ]
+    );
+}
+
+#[test]
+fn ignores_a_capture_the_mapping_does_not_name() {
+    let roles = roles_for(
+        "struct P {\n    x: i32,\n}\n",
+        "(struct_item name: (type_identifier) @kind.type)\n(field_declaration name: (field_identifier) @unmapped)",
+        &[("kind.type", Role::Type)],
+    );
+
+    assert_eq!(roles, vec![("P".to_string(), Role::Type)]);
+}
+
+#[test]
+fn labels_every_match_of_a_repeated_pattern() {
+    let roles = roles_for(
+        "struct A;\nstruct B;\n",
+        "(struct_item name: (type_identifier) @kind.type)",
+        &[("kind.type", Role::Type)],
+    );
+
+    assert_eq!(roles.len(), 2, "{roles:?}");
+}
+
+#[test]
+fn reports_a_malformed_query_rather_than_silently_matching_nothing() {
+    let source = "struct P;\n";
+    let (_, _) = analyze_content(source.to_string(), Language::Rust).unwrap();
+    let tree = parse(source);
+
+    let error = capture_roles(
+        "(no_such_node) @kind.type",
+        source,
+        tree.root_node(),
+        &[("kind.type", Role::Type)],
+    )
+    .unwrap_err();
+
+    assert!(error.contains("Failed to create query"), "{error}");
+}
+
+fn roles_for(source: &str, query: &str, mapping: &[(&str, Role)]) -> Vec<(String, Role)> {
+    let tree = parse(source);
+    let roles = capture_roles(query, source, tree.root_node(), mapping).unwrap();
+
+    let mut named: Vec<(usize, String, Role)> = collect_named(tree.root_node(), source, &roles);
+    named.sort_by_key(|(offset, _, _)| *offset);
+    named
+        .into_iter()
+        .map(|(_, name, role)| (name, role))
+        .collect()
+}
+
+fn collect_named(
+    node: tree_sitter::Node,
+    source: &str,
+    roles: &std::collections::HashMap<usize, Role>,
+) -> Vec<(usize, String, Role)> {
+    let mut found = vec![];
+    if let Some(role) = roles.get(&node.id()) {
+        found.push((
+            node.start_byte(),
+            node.utf8_text(source.as_bytes()).unwrap().to_string(),
+            role.clone(),
+        ));
+    }
+
+    let mut cursor = node.walk();
+    let children: Vec<tree_sitter::Node> = node.children(&mut cursor).collect();
+    for child in children {
+        found.extend(collect_named(child, source, roles));
+    }
+    found
+}
+
+fn parse(source: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .unwrap();
+    parser.parse(source, None).unwrap()
+}

--- a/crates/core/tests/unit/query/mod.rs
+++ b/crates/core/tests/unit/query/mod.rs
@@ -1,0 +1,1 @@
+mod capture_roles_tests;

--- a/docs/development/queries.md
+++ b/docs/development/queries.md
@@ -1,0 +1,58 @@
+## Locating declarations with queries
+
+Declarations whose shape alone identifies them are found by a tree-sitter query rather than by
+hand-written traversal. The pattern lives in a `.scm` file, and Rust supplies only a table saying
+what each capture means.
+
+### Where things live
+
+```
+crates/core/queries/<language>/definitions.scm   the patterns
+crates/core/src/languages/<language>/definition_queries.rs   capture name -> DefinitionType
+crates/core/src/query/mod.rs                     runs a query, returns roles keyed by node
+```
+
+Query files are embedded with `include_str!`, so the binary stays self-contained and a malformed
+query is caught by the tests rather than at a user's runtime.
+
+### Adding a declaration kind
+
+Capture the node that holds the **name**, not the item:
+
+```scheme
+(enum_item name: (type_identifier) @definition.enum)
+```
+
+The captured node's position becomes the declaration's position, which is what resolution matches
+against, and the scope it lands in is the one the traverser is inside when it reaches that node.
+
+Then map the capture name in `definition_queries.rs`:
+
+```rust
+("definition.enum", DefinitionType::EnumDefinition),
+```
+
+A capture name absent from the table is ignored, so a query may capture nodes for other purposes.
+
+### What stays in the extractor
+
+A query describes shape. When classifying needs more than shape, the extractor keeps the arm:
+
+- `function_item` is a `MethodDefinition` inside an `impl` and a `FunctionDefinition` outside it,
+  which the query cannot see
+- `let` patterns need their bindings told apart from the type they match, and a path component from
+  a binding
+- format string captures do not exist as nodes at all and are parsed out of the literal
+
+The extractor asks the query **first** and falls through to its arms only when nothing was captured.
+That ordering matters: a `const_item`'s name is an `identifier`, and the `identifier` arm would
+otherwise swallow it before the query was consulted.
+
+### Adding a language
+
+1. Write `crates/core/queries/<language>/definitions.scm`
+2. Write the mapping table beside its extractor
+3. Call `declared_types` from the extractor's constructor and consult it first
+
+The accuracy fixtures (`crates/accuracy`) are the check: migrating a kind should leave the recorded
+numbers untouched, since the point is to move where a pattern is written rather than what it finds.


### PR DESCRIPTION
First increment on #170. **Does not close it** — this migrates Rust declaration extraction; usages, scopes and TypeScript remain.

## What moves

Fourteen node kinds were each handled by a near-identical function: find the `name:` child, build a `Definition` of a fixed type. That pattern belongs in a query file.

```scheme
(struct_item name: (type_identifier) @definition.struct)
(enum_variant name: (identifier) @definition.enum_variant)
(const_item name: (identifier) @definition.const)
(field_declaration name: (field_identifier) @definition.field)
...
```

Plus a table saying what each capture means:

```rust
("definition.struct", DefinitionType::StructDefinition),
```

The fourteen functions go — **101 lines** out of the extractor, and adding a declaration kind is now two lines in two files rather than a new function.

## Infrastructure

`crates/core/src/query/mod.rs` runs a query once per file and returns the role of each captured node, keyed by node id. It is language-neutral: the query file names roles, the language supplies the mapping. A capture name absent from the table is ignored, so a query may capture nodes for other purposes.

Queries are embedded with `include_str!`, so the binary stays self-contained and a malformed query fails a test rather than a user's run.

## The ordering bug worth recording

The first attempt put the query in the `_ =>` fallback arm. It lost **every const, static, module and enum variant** while structs and fields kept working — because those names are `identifier` nodes, and the extractor's `identifier` arm returned `vec![]` before the fallback was reached. `type_identifier` and `field_identifier` names had no arm, so those went through.

The query is now consulted **first**, with the arms as exceptions. That is the right structure anyway: the query is the primary source.

Caught by the accuracy fixtures in one measurement, which is the whole reason for doing this after the harness rather than before.

## What deliberately stays

A query describes shape. Where classifying needs more:

- `function_item` is a `MethodDefinition` inside an `impl` and a `FunctionDefinition` outside
- `let` patterns need bindings told apart from the type they match, and path components from bindings
- format string captures are not nodes at all

## Behaviour unchanged

```
accuracy matches the recorded baseline
879 tests passing
no snapshot moves
```

Which is the point: this moves *where a pattern is written*, not what it finds.

## Also

- 4 tests for the query runner: role mapping, ignoring unmapped captures, repeated matches, and a malformed query reporting rather than silently matching nothing
- `docs/development/queries.md` documents the layout, how to add a kind, what stays in the extractor and why, and the three steps to add a language — the last open task on #170's list that this touches

## Remaining on #170

Rust usage extraction, scope detection, TypeScript and TSX, and the `RustImplCollector` question from #180. Each is its own increment, verifiable the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Rust code analysis to identify declarations more consistently, including structs, enums, functions, traits, modules, imports, macros, and type-related items.
  * Added query-based declaration matching for more reliable source-code extraction.

* **Documentation**
  * Added guidance for configuring declaration queries and adding support for new declaration types or languages.

* **Tests**
  * Added coverage for declaration-query matching, repeated results, ignored captures, and invalid queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->