### PR TITLE
feat(core): locate TypeScript declarations by query too

### DIFF
--- a/crates/core/queries/typescript/definitions.scm
+++ b/crates/core/queries/typescript/definitions.scm
@@ -1,0 +1,32 @@
+; TypeScript declarations whose name is simply the `name:` field of the declaration.
+;
+; Each capture names what the declaration is; the mapping table beside this file turns that into a
+; DefinitionType and says whether it hoists. Declarations needing more than the node's shape stay in
+; the extractor: a `variable_declarator` hoists or not depending on its keyword, and a constructor
+; parameter may declare a property.
+;
+; A namespace is an `internal_module` in this grammar; there is no `namespace_declaration` node.
+
+(class_declaration name: (type_identifier) @definition.class)
+(abstract_class_declaration name: (type_identifier) @definition.class)
+
+(interface_declaration name: (type_identifier) @definition.interface)
+(type_alias_declaration name: (type_identifier) @definition.type_alias)
+(enum_declaration name: (identifier) @definition.enum)
+
+(internal_module name: (identifier) @definition.namespace)
+
+(function_declaration name: (identifier) @definition.function)
+
+(method_definition name: (property_identifier) @definition.method)
+(method_definition name: (private_property_identifier) @definition.method)
+(method_signature name: (property_identifier) @definition.method)
+(abstract_method_signature name: (property_identifier) @definition.method)
+
+(property_signature name: (property_identifier) @definition.property)
+(public_field_definition name: (property_identifier) @definition.property)
+(public_field_definition name: (private_property_identifier) @definition.property)
+
+(import_specifier name: (identifier) @definition.import)
+
+(type_parameter name: (type_identifier) @definition.type_parameter)

--- a/crates/core/src/languages/language_factory.rs
+++ b/crates/core/src/languages/language_factory.rs
@@ -16,12 +16,12 @@ pub fn analyze_code_unified<'a>(
 
     match language {
         Language::Rust => {
-            let def_extractor = RustDefinitionExtractor::new(source_code, root_node);
+            let def_extractor = RustDefinitionExtractor::new(source_code, root_node)?;
             let usage_extractor = RustUsageExtractor;
             Ok(traverser.traverse(root_node, source_code, &def_extractor, &usage_extractor))
         }
         Language::TypeScript | Language::TSX => {
-            let def_extractor = TypeScriptDefinitionExtractor;
+            let def_extractor = TypeScriptDefinitionExtractor::new(source_code, root_node)?;
             let usage_extractor = TypeScriptUsageExtractor;
             Ok(traverser.traverse(root_node, source_code, &def_extractor, &usage_extractor))
         }

--- a/crates/core/src/languages/rust/definition_queries.rs
+++ b/crates/core/src/languages/rust/definition_queries.rs
@@ -1,33 +1,59 @@
 use crate::models::DefinitionType;
-use crate::query::{self, Roles};
+use crate::query::{self, DeclaredAs, Roles};
 use tree_sitter::Node;
 
 /// Declarations located by query rather than by hand-written traversal.
 const QUERY: &str = include_str!("../../../queries/rust/definitions.scm");
 
 /// What each capture in that file means.
-const ROLES: [(&str, DefinitionType); 10] = [
-    ("definition.struct", DefinitionType::StructDefinition),
-    ("definition.enum", DefinitionType::EnumDefinition),
+const ROLES: [(&str, DeclaredAs); 10] = [
+    (
+        "definition.struct",
+        DeclaredAs::plain(DefinitionType::StructDefinition),
+    ),
+    (
+        "definition.enum",
+        DeclaredAs::plain(DefinitionType::EnumDefinition),
+    ),
     (
         "definition.enum_variant",
-        DefinitionType::EnumVariantDefinition,
+        DeclaredAs::plain(DefinitionType::EnumVariantDefinition),
     ),
-    ("definition.type", DefinitionType::TypeDefinition),
-    ("definition.module", DefinitionType::ModuleDefinition),
-    ("definition.const", DefinitionType::ConstDefinition),
-    ("definition.variable", DefinitionType::VariableDefinition),
-    ("definition.function", DefinitionType::FunctionDefinition),
-    ("definition.field", DefinitionType::StructFieldDefinition),
-    ("definition.macro", DefinitionType::MacroDefinition),
+    (
+        "definition.type",
+        DeclaredAs::plain(DefinitionType::TypeDefinition),
+    ),
+    (
+        "definition.module",
+        DeclaredAs::plain(DefinitionType::ModuleDefinition),
+    ),
+    (
+        "definition.const",
+        DeclaredAs::plain(DefinitionType::ConstDefinition),
+    ),
+    (
+        "definition.variable",
+        DeclaredAs::plain(DefinitionType::VariableDefinition),
+    ),
+    (
+        "definition.function",
+        DeclaredAs::plain(DefinitionType::FunctionDefinition),
+    ),
+    (
+        "definition.field",
+        DeclaredAs::plain(DefinitionType::StructFieldDefinition),
+    ),
+    (
+        "definition.macro",
+        DeclaredAs::plain(DefinitionType::MacroDefinition),
+    ),
 ];
 
 /// Run the declaration query over a file, giving the kind of declaration each captured name node
 /// introduces.
 ///
-/// A malformed query is a bug in the file beside this one rather than something a caller can act
-/// on, so an empty map is returned and analysis continues with whatever the extractor still handles
-/// itself.
-pub fn declared_types(source_code: &str, root_node: Node) -> Roles<DefinitionType> {
-    query::capture_roles(QUERY, source_code, root_node, &ROLES).unwrap_or_default()
+/// A malformed query is a bug in the file beside this one, and swallowing it would empty the
+/// definition list rather than fail, so the error is returned.
+pub fn declared_types(source_code: &str, root_node: Node) -> Result<Roles<DeclaredAs>, String> {
+    query::capture_roles(QUERY, source_code, root_node, &ROLES)
 }

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -5,7 +5,7 @@ use crate::models::{
     ast_traverser::{NodeDefinitionExtractor, NodeUsageExtractor},
     Definition, DefinitionType, Position, ScopeId, ScopeType, Usage, UsageKind,
 };
-use crate::query::Roles;
+use crate::query::{DeclaredAs, Roles};
 
 /// Rust-specific definition extractor
 ///
@@ -13,19 +13,21 @@ use crate::query::Roles;
 /// `queries/rust/definitions.scm`; the arms below handle the rest, where classifying needs more
 /// than the node — a `function_item` is a method inside an impl and a function outside it.
 pub struct RustDefinitionExtractor {
-    declared_types: Roles<DefinitionType>,
+    declared_types: Roles<DeclaredAs>,
 }
 
 impl RustDefinitionExtractor {
-    pub fn new(source_code: &str, root_node: Node) -> Self {
-        Self {
-            declared_types: super::definition_queries::declared_types(source_code, root_node),
-        }
+    /// Fails if the declaration query does not compile, which is a bug in the `.scm` file rather
+    /// than anything about the source being analyzed.
+    pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
+        Ok(Self {
+            declared_types: super::definition_queries::declared_types(source_code, root_node)?,
+        })
     }
 
     /// The declaration this node introduces, if the query located one here.
     fn queried_definition(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Definition> {
-        let Some(definition_type) = self.declared_types.get(&node.id()) else {
+        let Some(declared) = self.declared_types.get(&node.id()) else {
             return vec![];
         };
         let Ok(name) = node.utf8_text(source.as_bytes()) else {
@@ -34,11 +36,11 @@ impl RustDefinitionExtractor {
 
         vec![Definition {
             name: name.to_string(),
-            definition_type: definition_type.clone(),
+            definition_type: declared.definition_type.clone(),
             position: Position::from_node(&node),
             scope_id: Some(scope),
             accessibility: None,
-            is_hoisted: Some(false),
+            is_hoisted: Some(declared.is_hoisted),
         }]
     }
 }

--- a/crates/core/src/languages/typescript/definition_queries.rs
+++ b/crates/core/src/languages/typescript/definition_queries.rs
@@ -1,0 +1,55 @@
+use crate::models::DefinitionType;
+use crate::query::{self, DeclaredAs, Roles};
+use tree_sitter::Node;
+
+/// Declarations located by query rather than by hand-written traversal.
+const QUERY: &str = include_str!("../../../queries/typescript/definitions.scm");
+
+/// What each capture in that file means, and whether it hoists.
+const ROLES: [(&str, DeclaredAs); 10] = [
+    (
+        "definition.class",
+        DeclaredAs::hoisted(DefinitionType::ClassDefinition),
+    ),
+    (
+        "definition.interface",
+        DeclaredAs::hoisted(DefinitionType::InterfaceDefinition),
+    ),
+    (
+        "definition.type_alias",
+        DeclaredAs::hoisted(DefinitionType::TypeDefinition),
+    ),
+    (
+        "definition.enum",
+        DeclaredAs::hoisted(DefinitionType::EnumDefinition),
+    ),
+    (
+        "definition.namespace",
+        DeclaredAs::hoisted(DefinitionType::ModuleDefinition),
+    ),
+    (
+        "definition.function",
+        DeclaredAs::hoisted(DefinitionType::FunctionDefinition),
+    ),
+    (
+        "definition.method",
+        DeclaredAs::plain(DefinitionType::MethodDefinition),
+    ),
+    (
+        "definition.property",
+        DeclaredAs::plain(DefinitionType::PropertyDefinition),
+    ),
+    (
+        "definition.import",
+        DeclaredAs::plain(DefinitionType::ImportDefinition),
+    ),
+    (
+        "definition.type_parameter",
+        DeclaredAs::plain(DefinitionType::TypeDefinition),
+    ),
+];
+
+/// Run the declaration query over a file, giving what each captured name node declares.
+pub fn declared_types(source_code: &str, root_node: Node) -> Result<Roles<DeclaredAs>, String> {
+    query::capture_roles(QUERY, source_code, root_node, &ROLES)
+}

--- a/crates/core/src/languages/typescript/mod.rs
+++ b/crates/core/src/languages/typescript/mod.rs
@@ -1,3 +1,4 @@
+pub mod definition_queries;
 pub mod dependency_resolver;
 pub mod formatter;
 pub mod typescript_node_extractors;

--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -4,65 +4,61 @@ use crate::models::{
     ast_traverser::{NodeDefinitionExtractor, NodeUsageExtractor},
     Definition, DefinitionType, Position, ScopeId, ScopeType, Usage, UsageKind,
 };
+use crate::query::{DeclaredAs, Roles};
 
 /// TypeScript-specific definition extractor
-pub struct TypeScriptDefinitionExtractor;
+///
+/// Declarations whose shape alone identifies them are located by
+/// `queries/typescript/definitions.scm`; the arms below handle the rest, where classifying needs
+/// more than the node — a `variable_declarator` hoists or not depending on its keyword, and a
+/// constructor parameter may declare a property.
+pub struct TypeScriptDefinitionExtractor {
+    declared_types: Roles<DeclaredAs>,
+}
+
+impl TypeScriptDefinitionExtractor {
+    /// Fails if the declaration query does not compile, which is a bug in the `.scm` file rather
+    /// than anything about the source being analyzed.
+    pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
+        Ok(Self {
+            declared_types: super::definition_queries::declared_types(source_code, root_node)?,
+        })
+    }
+
+    /// The declaration this node introduces, if the query located one here.
+    fn queried_definition(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Definition> {
+        let Some(declared) = self.declared_types.get(&node.id()) else {
+            return vec![];
+        };
+        let Ok(name) = node.utf8_text(source.as_bytes()) else {
+            return vec![];
+        };
+
+        vec![Definition {
+            name: Usage::normalize_line_endings(name),
+            definition_type: declared.definition_type.clone(),
+            position: Position::from_node(&node),
+            scope_id: Some(scope),
+            accessibility: None,
+            is_hoisted: Some(declared.is_hoisted),
+        }]
+    }
+}
 
 impl NodeDefinitionExtractor for TypeScriptDefinitionExtractor {
     fn extract_definition(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Definition> {
+        // The query is the primary source; the arms below are the exceptions it cannot express.
+        // Asking it first also keeps a name node from being swallowed by a kind arm.
+        let queried = self.queried_definition(node, scope, source);
+        if !queried.is_empty() {
+            return queried;
+        }
+
         match node.kind() {
-            "function_declaration" => self
-                .extract_function_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "method_definition" => self
-                .extract_method_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "arrow_function" => self.extract_arrow_function_definition(node, scope, source),
-            "class_declaration" | "abstract_class_declaration" => self
-                .extract_class_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "interface_declaration" => self
-                .extract_interface_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "type_alias_declaration" => self
-                .extract_type_alias_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "enum_declaration" => self
-                .extract_enum_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "namespace_declaration" | "internal_module" => self
-                .extract_namespace_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "variable_declarator" => self.extract_variable_definition(node, scope, source),
             "formal_parameters" => self.extract_function_parameters(node, scope, source),
-            "type_parameter" => self
-                .extract_type_parameter_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "enum_body" => self.extract_enum_members(node, scope, source),
-            "public_field_definition" | "private_field_definition" | "field_definition" => self
-                .extract_field_definition(node, scope, source)
-                .into_iter()
-                .collect(),
-            "property_signature" => self
-                .extract_property_signature(node, scope, source)
-                .into_iter()
-                .collect(),
-            "method_signature" | "abstract_method_signature" => self
-                .extract_method_signature(node, scope, source)
-                .into_iter()
-                .collect(),
-            "import_specifier" => self
-                .extract_import_specifier_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "import_statement" => self
                 .extract_import_statement_definition(node, scope, source)
                 .into_iter()
@@ -99,44 +95,6 @@ impl NodeDefinitionExtractor for TypeScriptDefinitionExtractor {
 }
 
 impl TypeScriptDefinitionExtractor {
-    fn extract_function_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::FunctionDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(true), // Functions are hoisted in TypeScript/JavaScript
-        })
-    }
-
-    fn extract_method_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::MethodDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
     fn extract_arrow_function_definition(
         &self,
         node: Node,
@@ -163,101 +121,6 @@ impl TypeScriptDefinitionExtractor {
         }
 
         definitions
-    }
-
-    fn extract_class_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::ClassDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(true), // Classes are hoisted
-        })
-    }
-
-    fn extract_interface_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::InterfaceDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(true),
-        })
-    }
-
-    fn extract_type_alias_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::TypeDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(true),
-        })
-    }
-
-    fn extract_enum_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::EnumDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(true),
-        })
-    }
-
-    fn extract_namespace_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::ModuleDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(true),
-        })
     }
 
     fn extract_variable_definition(
@@ -404,63 +267,6 @@ impl TypeScriptDefinitionExtractor {
         })
     }
 
-    fn extract_property_signature(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::PropertyDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_method_signature(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::MethodDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
-    fn extract_import_specifier_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::ImportDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false), // Match old implementation
-        })
-    }
-
     fn extract_import_statement_definition(
         &self,
         _node: Node,
@@ -527,25 +333,6 @@ impl TypeScriptDefinitionExtractor {
         None
     }
 
-    fn extract_type_parameter_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::TypeDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
-    }
-
     fn extract_enum_members(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Definition> {
         let mut definitions = vec![];
         let mut cursor = node.walk();
@@ -566,25 +353,6 @@ impl TypeScriptDefinitionExtractor {
         }
 
         definitions
-    }
-
-    fn extract_field_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        let name = self.find_child_by_field_name(node, "name")?;
-        let name_text = name.utf8_text(source.as_bytes()).ok()?;
-
-        Some(Definition {
-            name: Usage::normalize_line_endings(name_text),
-            definition_type: DefinitionType::PropertyDefinition,
-            position: Position::from_node(&name),
-            scope_id: Some(scope),
-            accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-            is_hoisted: Some(false),
-        })
     }
 
     fn find_child_by_field_name<'a>(&self, node: Node<'a>, field_name: &str) -> Option<Node<'a>> {

--- a/crates/core/src/query/mod.rs
+++ b/crates/core/src/query/mod.rs
@@ -54,3 +54,29 @@ fn indexed_roles<T: Clone>(query: &Query, mapping: &[(&str, T)]) -> HashMap<u32,
         })
         .collect()
 }
+
+/// What a captured name node declares.
+///
+/// Both languages need the kind, and TypeScript needs hoisting as well — a class is visible before
+/// its declaration while a method is not — so it travels with the role rather than being assumed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeclaredAs {
+    pub definition_type: crate::models::DefinitionType,
+    pub is_hoisted: bool,
+}
+
+impl DeclaredAs {
+    pub const fn plain(definition_type: crate::models::DefinitionType) -> Self {
+        Self {
+            definition_type,
+            is_hoisted: false,
+        }
+    }
+
+    pub const fn hoisted(definition_type: crate::models::DefinitionType) -> Self {
+        Self {
+            definition_type,
+            is_hoisted: true,
+        }
+    }
+}

--- a/crates/core/tests/unit/query/mod.rs
+++ b/crates/core/tests/unit/query/mod.rs
@@ -1,1 +1,2 @@
 mod capture_roles_tests;
+mod query_files_tests;

--- a/crates/core/tests/unit/query/query_files_tests.rs
+++ b/crates/core/tests/unit/query/query_files_tests.rs
@@ -1,0 +1,43 @@
+use lintric_core::languages::{rust, typescript};
+use lintric_core::{analyze_content, Language};
+
+/// A query that fails to compile yields no captures, and the extractors treat that as "nothing
+/// declared here" — so a typo in a `.scm` file would silently empty the definition list rather than
+/// fail. These assert the files compile against the grammar they are written for.
+#[test]
+fn the_rust_definition_query_compiles_and_matches() {
+    let source = "struct P {\n    x: i32,\n}\n";
+    let (ir, _) = analyze_content(source.to_string(), Language::Rust).unwrap();
+
+    assert!(
+        ir.definitions.iter().any(|d| d.name == "P"),
+        "{:?}",
+        ir.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+    );
+    let _ = rust::definition_queries::declared_types;
+}
+
+#[test]
+fn the_typescript_definition_query_compiles_and_matches() {
+    let source = "class C {\n    m(): number {\n        return 1;\n    }\n}\n";
+    let (ir, _) = analyze_content(source.to_string(), Language::TypeScript).unwrap();
+
+    assert!(
+        ir.definitions.iter().any(|d| d.name == "C"),
+        "{:?}",
+        ir.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+    );
+    let _ = typescript::definition_queries::declared_types;
+}
+
+#[test]
+fn the_typescript_definition_query_compiles_against_tsx_too() {
+    let source = "class C {\n    m(): number {\n        return 1;\n    }\n}\n";
+    let (ir, _) = analyze_content(source.to_string(), Language::TSX).unwrap();
+
+    assert!(
+        ir.definitions.iter().any(|d| d.name == "C"),
+        "{:?}",
+        ir.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+    );
+}

--- a/docs/development/queries.md
+++ b/docs/development/queries.md
@@ -7,9 +7,9 @@ what each capture means.
 ### Where things live
 
 ```
-crates/core/queries/<language>/definitions.scm   the patterns
-crates/core/src/languages/<language>/definition_queries.rs   capture name -> DefinitionType
-crates/core/src/query/mod.rs                     runs a query, returns roles keyed by node
+crates/core/queries/<language>/definitions.scm               the patterns
+crates/core/src/languages/<language>/definition_queries.rs   capture name -> what it declares
+crates/core/src/query/mod.rs                                 runs a query, returns roles keyed by node
 ```
 
 Query files are embedded with `include_str!`, so the binary stays self-contained and a malformed
@@ -26,10 +26,12 @@ Capture the node that holds the **name**, not the item:
 The captured node's position becomes the declaration's position, which is what resolution matches
 against, and the scope it lands in is the one the traverser is inside when it reaches that node.
 
-Then map the capture name in `definition_queries.rs`:
+Then map the capture name in `definition_queries.rs`, saying whether the declaration hoists —
+visible before its own line, as a class is and a method is not:
 
 ```rust
-("definition.enum", DefinitionType::EnumDefinition),
+("definition.enum", DeclaredAs::hoisted(DefinitionType::EnumDefinition)),
+("definition.method", DeclaredAs::plain(DefinitionType::MethodDefinition)),
 ```
 
 A capture name absent from the table is ignored, so a query may capture nodes for other purposes.
@@ -47,6 +49,17 @@ A query describes shape. When classifying needs more than shape, the extractor k
 The extractor asks the query **first** and falls through to its arms only when nothing was captured.
 That ordering matters: a `const_item`'s name is an `identifier`, and the `identifier` arm would
 otherwise swallow it before the query was consulted.
+
+### A broken query must fail loudly
+
+`declared_types` returns a `Result`. An earlier version swallowed the error and returned no
+captures, which the extractors read as "nothing declared here" — so one invalid node name emptied
+the whole definition list instead of failing. That is how a `namespace_declaration` typo (the
+grammar calls it `internal_module`) went unnoticed until the accuracy fixtures reported every
+TypeScript declaration missing.
+
+`crates/core/tests/unit/query/query_files_tests.rs` asserts each file compiles against its grammar,
+including TSX, which is a separate grammar from TypeScript.
 
 ### Adding a language
 


### PR DESCRIPTION
Second increment on #170, following #221. Brings TypeScript to the same shape as Rust.

## What moves

Twelve more near-identical functions become query patterns:

```scheme
(class_declaration name: (type_identifier) @definition.class)
(abstract_class_declaration name: (type_identifier) @definition.class)
(interface_declaration name: (type_identifier) @definition.interface)
(method_definition name: (property_identifier) @definition.method)
(public_field_definition name: (private_property_identifier) @definition.property)
...
```

**193 lines out of that extractor, 895 → 702.** Both languages now go through the same runner.

TypeScript needed one thing Rust did not: **hoisting varies by kind** — a class is visible before its own line, a method is not. So the role carries it, and both languages share a `DeclaredAs`:

```rust
("definition.class",  DeclaredAs::hoisted(DefinitionType::ClassDefinition)),
("definition.method", DeclaredAs::plain(DefinitionType::MethodDefinition)),
```

## A broken query no longer passes silently

`declared_types` used to return an empty map on failure, which the extractors read as "nothing declared here". One invalid node name therefore **emptied the entire definition list rather than failing**.

That is not hypothetical — it happened here. This grammar has no `namespace_declaration`; it is `internal_module`. With the arms already removed, every TypeScript declaration vanished:

```
defs: []
```

`declared_types` now returns a `Result` that propagates, and `query_files_tests.rs` asserts each file compiles against its grammar — **including TSX, which is a separate grammar from TypeScript** and would not otherwise be checked.

The accuracy fixtures caught the disappearance in one measurement; the test now catches the cause directly.

## Behaviour unchanged

```
accuracy matches the recorded baseline
882 tests passing
no snapshot moves
```

## Running total on #170

| | Lines removed | Functions |
| --- | --- | --- |
| #221 Rust declarations | 101 | 14 |
| this change | 193 | 12 |

## Remaining

Rust and TypeScript usage extraction, scope detection, and the `RustImplCollector` question from #180. `docs/development/queries.md` gains the hoisting convention and the loud-failure rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)