### PR TITLE
refactor(rust): locate bindings by query instead of walking parents

### DIFF
--- a/crates/core/queries/rust/bindings.scm
+++ b/crates/core/queries/rust/bindings.scm
@@ -1,0 +1,41 @@
+; Identifiers that bind a name rather than reference one.
+;
+; The same node shape means different things by position: `x` in `let x = y` declares, `x` in
+; `f(x)` reads. Everything captured here is a declaration occurrence, and the usage extractor takes
+; anything else as a reference.
+;
+; @reference overrides @binding for the node it names, which is how the type a pattern matches
+; against is kept out of the bindings that pattern introduces.
+
+(let_declaration pattern: (identifier) @binding)
+(parameter pattern: (identifier) @binding)
+(for_expression pattern: (identifier) @binding)
+
+; Every identifier a pattern names directly is bound by it.
+(tuple_pattern (identifier) @binding)
+(slice_pattern (identifier) @binding)
+(reference_pattern (identifier) @binding)
+(ref_pattern (identifier) @binding)
+(closure_parameters (identifier) @binding)
+
+; `Wrap(inner)` binds `inner` and references `Wrap`.
+(tuple_struct_pattern (identifier) @binding)
+(tuple_struct_pattern type: (identifier) @reference)
+
+(type_parameter name: (type_identifier) @binding)
+(lifetime (identifier) @binding)
+(bounded_type (type_identifier) @binding)
+
+; A declaration's own name is not a use of itself.
+(function_item name: (identifier) @binding)
+(function_signature_item name: (identifier) @binding)
+(struct_item name: (type_identifier) @binding)
+(union_item name: (type_identifier) @binding)
+(enum_item name: (type_identifier) @binding)
+(enum_variant name: (identifier) @binding)
+(trait_item name: (type_identifier) @binding)
+(mod_item name: (identifier) @binding)
+(const_item name: (identifier) @binding)
+(static_item name: (identifier) @binding)
+(type_item name: (type_identifier) @binding)
+(associated_type name: (type_identifier) @binding)

--- a/crates/core/src/languages/language_factory.rs
+++ b/crates/core/src/languages/language_factory.rs
@@ -17,7 +17,7 @@ pub fn analyze_code_unified<'a>(
     match language {
         Language::Rust => {
             let def_extractor = RustDefinitionExtractor::new(source_code, root_node)?;
-            let usage_extractor = RustUsageExtractor;
+            let usage_extractor = RustUsageExtractor::new(source_code, root_node)?;
             Ok(traverser.traverse(root_node, source_code, &def_extractor, &usage_extractor))
         }
         Language::TypeScript | Language::TSX => {

--- a/crates/core/src/languages/rust/binding_queries.rs
+++ b/crates/core/src/languages/rust/binding_queries.rs
@@ -1,0 +1,21 @@
+use crate::query;
+use std::collections::HashSet;
+use tree_sitter::Node;
+
+/// Identifiers that bind a name rather than reference one.
+const QUERY: &str = include_str!("../../../queries/rust/bindings.scm");
+
+/// The identifiers the query calls bindings, and the ones it calls references.
+///
+/// Both come from one file because they answer one question. A reference wins: the type a pattern
+/// matches against is a direct child of that pattern just as the names it introduces are, so the
+/// only thing telling them apart is the field, and a query cannot say "every child but this one".
+pub fn bindings_and_references(
+    source_code: &str,
+    root_node: Node,
+) -> Result<(HashSet<usize>, HashSet<usize>), String> {
+    Ok((
+        query::captured_nodes(QUERY, source_code, root_node, "binding")?,
+        query::captured_nodes(QUERY, source_code, root_node, "reference")?,
+    ))
+}

--- a/crates/core/src/languages/rust/mod.rs
+++ b/crates/core/src/languages/rust/mod.rs
@@ -1,3 +1,4 @@
+pub mod binding_queries;
 pub mod definition_queries;
 pub mod dependency_resolver;
 pub mod format_string;

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use tree_sitter::Node;
 
 use super::format_string;
@@ -488,7 +489,24 @@ impl RustDefinitionExtractor {
 }
 
 /// Rust-specific usage extractor
-pub struct RustUsageExtractor;
+pub struct RustUsageExtractor {
+    bindings: HashSet<usize>,
+    references: HashSet<usize>,
+}
+
+impl RustUsageExtractor {
+    /// Fails if the binding query does not compile, which is a bug in the `.scm` file rather than
+    /// anything about the source being analyzed.
+    pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
+        let (bindings, references) =
+            super::binding_queries::bindings_and_references(source_code, root_node)?;
+
+        Ok(Self {
+            bindings,
+            references,
+        })
+    }
+}
 
 impl NodeUsageExtractor for RustUsageExtractor {
     fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Usage> {
@@ -588,83 +606,12 @@ impl NodeUsageExtractor for RustUsageExtractor {
 }
 
 impl RustUsageExtractor {
+    /// Whether this identifier declares the name rather than reading it.
+    ///
+    /// The patterns live in `queries/rust/bindings.scm`; a reference capture wins, which is how the
+    /// type a pattern matches against stays a usage while the names it introduces do not.
     fn is_identifier_in_definition_context(&self, node: Node) -> bool {
-        // Use the same definition patterns as the original implementation
-        if let Some(parent) = node.parent() {
-            match parent.kind() {
-                "let_declaration" => {
-                    if let Some(pattern_field) = parent.child_by_field_name("pattern") {
-                        return node.id() == pattern_field.id();
-                    }
-                }
-                // Pattern types are definition contexts
-                "tuple_pattern" | "slice_pattern" | "reference_pattern" | "ref_pattern" => {
-                    // Identifiers inside patterns are definitions
-                    return true;
-                }
-                "struct_pattern" => {
-                    // Check if this is the type field (usage) or a field identifier (definition)
-                    if let Some(type_field) = parent.child_by_field_name("type") {
-                        if node.id() == type_field.id() {
-                            // This is the struct type being matched against (usage)
-                            return false;
-                        }
-                    }
-                    // Other identifiers in struct_pattern are field bindings (definitions)
-                    return true;
-                }
-                "tuple_struct_pattern" => {
-                    // The type being matched is a reference; the elements are bindings.
-                    if let Some(type_field) = parent.child_by_field_name("type") {
-                        return node.id() != type_field.id();
-                    }
-                    return true;
-                }
-                "parameter" => {
-                    if let Some(pattern_field) = parent.child_by_field_name("pattern") {
-                        return node.id() == pattern_field.id();
-                    }
-                }
-                "for_expression" => {
-                    if let Some(pattern_field) = parent.child_by_field_name("pattern") {
-                        return node.id() == pattern_field.id();
-                    }
-                }
-                "closure_parameters" => return true,
-                "type_parameters" => return true,
-                // `T` in `<T>` sits under a `type_parameter`, so the list above never sees it and
-                // the declaration was being collected as a usage
-                "type_parameter" => {
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        return node.id() == name_field.id();
-                    }
-                    return true;
-                }
-                "lifetime" => return true,
-                "trait_bounds" => return false,
-                "where_clause" => return true,
-                "bounded_type" => return true,
-                "constrained_type_parameter" => return true,
-                "function_item"
-                | "struct_item"
-                | "union_item"
-                | "enum_item"
-                | "trait_item"
-                | "mod_item"
-                | "const_item"
-                | "static_item"
-                | "type_item"
-                | "associated_type"
-                | "function_signature_item"
-                | "enum_variant" => {
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        return node.id() == name_field.id();
-                    }
-                }
-                _ => {}
-            }
-        }
-        false
+        self.bindings.contains(&node.id()) && !self.references.contains(&node.id())
     }
 
     fn is_function_name_in_call_expression(&self, node: Node) -> bool {

--- a/crates/core/src/query/mod.rs
+++ b/crates/core/src/query/mod.rs
@@ -5,7 +5,7 @@
 //! and this module returns the answer keyed by node, so an extractor can ask about the node it is
 //! looking at without repeating the pattern in Rust.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Query, QueryCursor};
 
@@ -53,6 +53,21 @@ fn indexed_roles<T: Clone>(query: &Query, mapping: &[(&str, T)]) -> HashMap<u32,
                 .map(|index| (index, role.clone()))
         })
         .collect()
+}
+
+/// The nodes one capture name matches, as a set of node ids.
+///
+/// Useful when the query answers a yes-or-no question about a node — whether an identifier binds a
+/// name or reads one — rather than labelling it.
+pub fn captured_nodes(
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+    capture: &str,
+) -> Result<HashSet<usize>, String> {
+    let roles = capture_roles(query_source, source_code, root_node, &[(capture, ())])?;
+
+    Ok(roles.into_keys().collect())
 }
 
 /// What a captured name node declares.

--- a/crates/core/tests/unit/query/query_files_tests.rs
+++ b/crates/core/tests/unit/query/query_files_tests.rs
@@ -60,3 +60,20 @@ fn the_receiver_narrowing_queries_compile_for_both_typescript_grammars() {
         );
     }
 }
+
+#[test]
+fn the_rust_binding_query_compiles_and_tells_a_binding_from_a_reference() {
+    // `Meters` is read while `value` is introduced, though both are direct children of the pattern.
+    let source = "struct Meters(i32);\nfn main() {\n    let m = Meters(1);\n    let Meters(value) = m;\n    let _ = value;\n}\n";
+    let (ir, _) = analyze_content(source.to_string(), Language::Rust).unwrap();
+
+    let edges: Vec<(usize, usize, &str)> = ir
+        .dependencies
+        .iter()
+        .map(|d| (d.source_line, d.target_line, d.symbol.as_str()))
+        .collect();
+
+    assert!(edges.contains(&(4, 1, "Meters")), "{edges:?}");
+    assert!(edges.contains(&(5, 4, "value")), "{edges:?}");
+    let _ = rust::binding_queries::bindings_and_references;
+}

--- a/docs/development/queries.md
+++ b/docs/development/queries.md
@@ -9,6 +9,7 @@ what each capture means.
 ```
 crates/core/queries/<language>/definitions.scm               declaration patterns
 crates/core/queries/<language>/scopes.scm                    scope patterns
+crates/core/queries/<language>/bindings.scm                  which identifiers bind rather than read
 crates/core/src/languages/<language>/definition_queries.rs   capture name -> what it declares
 crates/core/src/query/mod.rs                                 runs a query, returns roles keyed by node
 ```
@@ -50,6 +51,25 @@ A query describes shape. When classifying needs more than shape, the extractor k
 The extractor asks the query **first** and falls through to its arms only when nothing was captured.
 That ordering matters: a `const_item`'s name is an `identifier`, and the `identifier` arm would
 otherwise swallow it before the query was consulted.
+
+### Bindings
+
+The same node shape means different things by position: `x` in `let x = y` declares a name, `x` in
+`f(x)` reads one. `bindings.scm` captures the declaring occurrences, and the usage extractor takes
+everything else as a reference — replacing a walk up the parent chain with a set lookup.
+
+One case a query cannot state directly is "every child of this pattern except the type it matches
+against", since there is no way to exclude a field. So the type is captured as `@reference` and a
+reference wins over a binding for the same node:
+
+```scheme
+(tuple_struct_pattern (identifier) @binding)
+(tuple_struct_pattern type: (identifier) @reference)
+```
+
+Writing the patterns out also showed which of the hand-written arms could never fire:
+`constrained_type_parameter` is not a node in this grammar at all, and `where_clause` and
+`type_parameters` have no identifier among their children. They are gone rather than transcribed.
 
 ### Scopes
 


### PR DESCRIPTION
Part of #170.

`is_identifier_in_definition_context` was 75 lines of parent-kind dispatch deciding whether an identifier declares a name or reads one. Every arm re-derived a structural pattern that tree-sitter's query language states directly, so it moves to `queries/rust/bindings.scm` and the extractor does a set lookup.

## The one thing a query cannot say

"Every child of this pattern except the type it matches against" — there is no way to exclude a field. So the type is captured separately and a reference wins:

```scheme
(tuple_struct_pattern (identifier) @binding)
(tuple_struct_pattern type: (identifier) @reference)
```

`let Meters(value) = m` therefore reads `Meters` and introduces `value`, which the new test pins.

## Dead arms found by writing the patterns out

Three arms could never fire, so they are gone rather than transcribed:

| Arm | Why it never fired |
| --- | --- |
| `constrained_type_parameter` | not a node in tree-sitter-rust 0.24 at all |
| `where_clause` | its only child type is `where_predicate` |
| `type_parameters` | `T` in `<T>` sits under a `type_parameter` — the code's own comment already said so |

## Verification

The point of a refactor is that nothing changes, and the harness is what can say so:

- accuracy `454 / 454`, precision 1.000, recall 1.000 — **identical to the recorded baseline**
- `cargo test --workspace` green, no snapshot changes across 352 snapshots
- `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

`rust_node_extractors.rs` 1095 → 1042 lines; the patterns are now 41 lines of `.scm` readable on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Rust code analysis to more accurately distinguish declarations from references across patterns, parameters, type definitions, and other syntax.
  - Improved dependency and usage relationships for Rust symbols.

- **Documentation**
  - Added guidance for configuring and interpreting language binding queries.

- **Tests**
  - Added coverage verifying Rust bindings and references are identified correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->