### PR TITLE
refactor(typescript): locate bindings by query instead of walking parents

### DIFF
--- a/crates/core/queries/typescript/bindings.scm
+++ b/crates/core/queries/typescript/bindings.scm
@@ -1,0 +1,33 @@
+; Identifiers that bind a name rather than reference one.
+;
+; The same node shape means different things by position: `x` in `const x = y` declares, `x` in
+; `f(x)` reads. Everything captured as @binding is a declaration occurrence, and the usage extractor
+; takes anything else as a reference.
+
+; A declaration's own name is not a use of itself.
+(function_declaration name: (identifier) @binding)
+(enum_declaration name: (identifier) @binding)
+(internal_module name: (identifier) @binding)
+(variable_declarator name: (identifier) @binding)
+(import_specifier name: (identifier) @binding)
+
+(interface_declaration name: (type_identifier) @binding)
+(type_alias_declaration name: (type_identifier) @binding)
+(class_declaration name: (type_identifier) @binding)
+(abstract_class_declaration name: (type_identifier) @binding)
+(type_parameter name: (type_identifier) @binding)
+
+; Names a pattern or parameter list introduces.
+(array_pattern (identifier) @binding)
+(rest_pattern (identifier) @binding)
+(assignment_pattern left: (identifier) @binding)
+(required_parameter pattern: (identifier) @binding)
+(optional_parameter pattern: (identifier) @binding)
+(arrow_function parameter: (identifier) @binding)
+
+; `{ key: renamed }` binds `renamed` and reads `key`.
+(pair_pattern value: (identifier) @binding)
+
+; Not a binding, but not counted here either: the call expression itself is extracted as the usage,
+; so counting its callee again would record the same reference twice.
+(call_expression function: (identifier) @call_target)

--- a/crates/core/src/languages/language_factory.rs
+++ b/crates/core/src/languages/language_factory.rs
@@ -22,7 +22,7 @@ pub fn analyze_code_unified<'a>(
         }
         Language::TypeScript | Language::TSX => {
             let def_extractor = TypeScriptDefinitionExtractor::new(source_code, root_node)?;
-            let usage_extractor = TypeScriptUsageExtractor;
+            let usage_extractor = TypeScriptUsageExtractor::new(source_code, root_node)?;
             Ok(traverser.traverse(root_node, source_code, &def_extractor, &usage_extractor))
         }
     }

--- a/crates/core/src/languages/typescript/binding_queries.rs
+++ b/crates/core/src/languages/typescript/binding_queries.rs
@@ -1,0 +1,20 @@
+use crate::query;
+use std::collections::HashSet;
+use tree_sitter::Node;
+
+/// Identifiers that bind a name rather than reference one.
+const QUERY: &str = include_str!("../../../queries/typescript/bindings.scm");
+
+/// The identifiers the query calls bindings, and the callees it says are already counted.
+///
+/// Both come from one file because the extractor asks one question of it — whether this identifier
+/// is a reference worth recording — and the two reasons it may not be sit side by side.
+pub fn bindings_and_call_targets(
+    source_code: &str,
+    root_node: Node,
+) -> Result<(HashSet<usize>, HashSet<usize>), String> {
+    Ok((
+        query::captured_nodes(QUERY, source_code, root_node, "binding")?,
+        query::captured_nodes(QUERY, source_code, root_node, "call_target")?,
+    ))
+}

--- a/crates/core/src/languages/typescript/mod.rs
+++ b/crates/core/src/languages/typescript/mod.rs
@@ -1,3 +1,4 @@
+pub mod binding_queries;
 pub mod definition_queries;
 pub mod dependency_resolver;
 pub mod formatter;

--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use tree_sitter::Node;
 
 use crate::models::{
@@ -392,7 +393,24 @@ impl TypeScriptDefinitionExtractor {
 }
 
 /// TypeScript-specific usage extractor
-pub struct TypeScriptUsageExtractor;
+pub struct TypeScriptUsageExtractor {
+    bindings: HashSet<usize>,
+    call_targets: HashSet<usize>,
+}
+
+impl TypeScriptUsageExtractor {
+    /// Fails if the binding query does not compile, which is a bug in the `.scm` file rather than
+    /// anything about the source being analyzed.
+    pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
+        let (bindings, call_targets) =
+            super::binding_queries::bindings_and_call_targets(source_code, root_node)?;
+
+        Ok(Self {
+            bindings,
+            call_targets,
+        })
+    }
+}
 
 impl NodeUsageExtractor for TypeScriptUsageExtractor {
     fn extract_usage(&self, node: Node, scope: ScopeId, source: &str) -> Vec<Usage> {
@@ -429,84 +447,12 @@ impl NodeUsageExtractor for TypeScriptUsageExtractor {
 }
 
 impl TypeScriptUsageExtractor {
+    /// Whether this identifier reads a name, as opposed to declaring one or naming the callee of a
+    /// call expression that is already recorded as the usage.
+    ///
+    /// The patterns live in `queries/typescript/bindings.scm`.
     fn is_usage_context(&self, node: Node) -> bool {
-        if let Some(parent) = node.parent() {
-            match parent.kind() {
-                // These are definition contexts, not usage
-                "function_declaration"
-                | "class_declaration"
-                | "abstract_class_declaration"
-                | "interface_declaration"
-                | "type_alias_declaration"
-                | "enum_declaration"
-                | "namespace_declaration"
-                | "internal_module"
-                | "variable_declarator"
-                | "method_definition"
-                | "property_signature"
-                | "method_signature"
-                | "abstract_method_signature"
-                | "import_specifier" => {
-                    // Check if this identifier is the name being defined
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        return node.id() != name_field.id();
-                    }
-                }
-                // Destructuring patterns are definition contexts, not usage
-                "array_pattern" | "object_pattern" => {
-                    // Identifiers inside destructuring patterns are definitions
-                    return false;
-                }
-                "rest_pattern" => {
-                    // Identifiers inside rest patterns (like ...rest) are definitions
-                    return false;
-                }
-                "shorthand_property_identifier_pattern" => {
-                    // Shorthand property identifiers in destructuring are definitions
-                    return false;
-                }
-                "assignment_pattern" => {
-                    // In patterns like [first = 1], 'first' is definition, '1' might be usage
-                    if let Some(left_field) = parent.child_by_field_name("left") {
-                        // If this node is the left side (the identifier being defined), it's not usage
-                        return node.id() != left_field.id();
-                    }
-                }
-                "pair_pattern" => {
-                    // In patterns like { x: renamed }, only 'x' is usage, 'renamed' is definition
-                    if let Some(value_field) = parent.child_by_field_name("value") {
-                        // If this node is the value (the identifier being defined), it's not usage
-                        return node.id() != value_field.id();
-                    }
-                }
-                "required_parameter" | "optional_parameter" => {
-                    // Check if this is the parameter name
-                    if let Some(pattern_field) = parent.child_by_field_name("pattern") {
-                        return node.id() != pattern_field.id();
-                    }
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        return node.id() != name_field.id();
-                    }
-                }
-                "arrow_function" => {
-                    // Check if this identifier is a parameter of the arrow function
-                    // For single parameter arrow functions without parentheses: item => ...
-                    if let Some(parameter_field) = parent.child_by_field_name("parameter") {
-                        return node.id() != parameter_field.id();
-                    }
-                }
-                "call_expression" => {
-                    // Check if this identifier is the function name (function field) of call_expression
-                    // If so, it should not be treated as a separate identifier usage
-                    // because call_expression itself will handle the usage
-                    if let Some(function_field) = parent.child_by_field_name("function") {
-                        return node.id() != function_field.id();
-                    }
-                }
-                _ => {}
-            }
-        }
-        true
+        !self.bindings.contains(&node.id()) && !self.call_targets.contains(&node.id())
     }
 
     fn extract_identifier_usage(&self, node: Node, scope: ScopeId, source: &str) -> Option<Usage> {
@@ -669,28 +615,8 @@ impl TypeScriptUsageExtractor {
         })
     }
 
+    /// Whether this type identifier is the name a declaration introduces.
     fn is_type_identifier_in_definition_context(&self, node: Node) -> bool {
-        // Check if this type_identifier is directly defining something (the name being defined)
-        if let Some(parent) = node.parent() {
-            match parent.kind() {
-                "interface_declaration"
-                | "type_alias_declaration"
-                | "class_declaration"
-                | "abstract_class_declaration" => {
-                    // Check if this is the name field (being defined) or usage within the declaration
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        return node.id() == name_field.id();
-                    }
-                }
-                "type_parameter" => {
-                    // Type parameters are definitions
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        return node.id() == name_field.id();
-                    }
-                }
-                _ => {}
-            }
-        }
-        false
+        self.bindings.contains(&node.id())
     }
 }

--- a/crates/core/tests/unit/query/query_files_tests.rs
+++ b/crates/core/tests/unit/query/query_files_tests.rs
@@ -77,3 +77,25 @@ fn the_rust_binding_query_compiles_and_tells_a_binding_from_a_reference() {
     assert!(edges.contains(&(5, 4, "value")), "{edges:?}");
     let _ = rust::binding_queries::bindings_and_references;
 }
+
+#[test]
+fn the_typescript_binding_query_compiles_and_finds_a_renaming_binding() {
+    // `{ key: renamed }` reads `key` and introduces `renamed`, which the later line depends on.
+    let source = "interface P {\n    key: number;\n}\nfunction f(p: P): number {\n    const { key: renamed } = p;\n    return renamed;\n}\n";
+
+    for language in [Language::TypeScript, Language::TSX] {
+        let (ir, _) = analyze_content(source.to_string(), language.clone()).unwrap();
+
+        let edges: Vec<(usize, usize, &str)> = ir
+            .dependencies
+            .iter()
+            .map(|d| (d.source_line, d.target_line, d.symbol.as_str()))
+            .collect();
+
+        assert!(
+            edges.contains(&(6, 5, "renamed")),
+            "{language:?}: {edges:?}"
+        );
+    }
+    let _ = typescript::binding_queries::bindings_and_call_targets;
+}

--- a/docs/development/queries.md
+++ b/docs/development/queries.md
@@ -67,9 +67,20 @@ reference wins over a binding for the same node:
 (tuple_struct_pattern type: (identifier) @reference)
 ```
 
-Writing the patterns out also showed which of the hand-written arms could never fire:
-`constrained_type_parameter` is not a node in this grammar at all, and `where_clause` and
-`type_parameters` have no identifier among their children. They are gone rather than transcribed.
+TypeScript's file also carries `@call_target`, which is not a binding: a call expression is itself
+extracted as the usage, so counting its callee again would record the same reference twice.
+
+Writing the patterns out is what showed which hand-written arms could never fire. In Rust,
+`constrained_type_parameter` is not a node in the grammar at all, and `where_clause` and
+`type_parameters` have no identifier among their children. In TypeScript, `namespace_declaration` is
+the same non-existent node #222 found in `definitions.scm`, `shorthand_property_identifier_pattern`
+is a leaf so nothing has it as a parent, `object_pattern` has no bare identifier child, and eight
+arms named declarations whose `name:` is a `type_identifier` or `property_identifier` — never the
+`identifier` the function was consulted for. All are gone rather than transcribed.
+
+Checking a field against `node-types.json` before writing the pattern is worth the minute it takes:
+a field name the node does not have fails to compile, and a node type that cannot appear there
+compiles into a pattern that silently never matches.
 
 ### Scopes
 


### PR DESCRIPTION
Part of #170. Same move as #227, now for TypeScript.

`is_usage_context` and `is_type_identifier_in_definition_context` were 100 lines of parent-kind dispatch between them, deciding whether an identifier declares a name or reads one. Both are now set lookups over `queries/typescript/bindings.scm`.

The file also carries `@call_target`, which is not a binding — a call expression is itself extracted as the usage, so counting its callee again would record the same reference twice. Keeping it beside the bindings says why the extractor skips it.

## Eleven arms that could never fire

| Arm | Why |
| --- | --- |
| `namespace_declaration` | the same non-existent node #222 found in `definitions.scm` — the grammar calls it `internal_module` |
| `shorthand_property_identifier_pattern` | a leaf, so nothing has it as a parent |
| `object_pattern` | no bare `identifier` child; its children are pair, shorthand, rest and assignment patterns |
| 8 declaration arms | their `name:` is a `type_identifier` or `property_identifier`, never the `identifier` the function was consulted for |

Verified against `node-types.json` for both the TypeScript and TSX grammars rather than inferred, and they are gone rather than transcribed.

## Verification

Nothing should change, and the harness is what can say so:

- accuracy `454 / 454`, precision 1.000, recall 1.000 — **identical to the recorded baseline**
- `cargo test --workspace` green, no snapshot changes
- `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

`typescript_node_extractors.rs` 696 → 622 lines; the patterns are 33 lines of `.scm` readable on their own.

Both extractors now hold their query results and are constructed from the file, so a malformed `.scm` fails loudly instead of quietly finding nothing — the failure mode #222 was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)