### PR TITLE
refactor(rust): drop two more parent walks from usage extraction

### DIFF
--- a/crates/core/queries/rust/bindings.scm
+++ b/crates/core/queries/rust/bindings.scm
@@ -22,6 +22,11 @@
 (tuple_struct_pattern (identifier) @binding)
 (tuple_struct_pattern type: (identifier) @reference)
 
+; Not a binding, but not counted here either: the call expression itself is extracted as the usage,
+; so counting its callee again would record the same reference twice. A qualified callee such as
+; `HashMap::new` is deliberately absent — its path components are references worth recording.
+(call_expression function: (identifier) @call_target)
+
 (type_parameter name: (type_identifier) @binding)
 (lifetime (identifier) @binding)
 (bounded_type (type_identifier) @binding)

--- a/crates/core/src/languages/rust/binding_queries.rs
+++ b/crates/core/src/languages/rust/binding_queries.rs
@@ -5,17 +5,25 @@ use tree_sitter::Node;
 /// Identifiers that bind a name rather than reference one.
 const QUERY: &str = include_str!("../../../queries/rust/bindings.scm");
 
-/// The identifiers the query calls bindings, and the ones it calls references.
+/// What the query says about each identifier it captures.
 ///
-/// Both come from one file because they answer one question. A reference wins: the type a pattern
-/// matches against is a direct child of that pattern just as the names it introduces are, so the
-/// only thing telling them apart is the field, and a query cannot say "every child but this one".
-pub fn bindings_and_references(
-    source_code: &str,
-    root_node: Node,
-) -> Result<(HashSet<usize>, HashSet<usize>), String> {
-    Ok((
-        query::captured_nodes(QUERY, source_code, root_node, "binding")?,
-        query::captured_nodes(QUERY, source_code, root_node, "reference")?,
-    ))
+/// One file because the extractor asks one question of it — whether this identifier is a reference
+/// worth recording — and the reasons it may not be sit side by side.
+pub struct Roles {
+    /// Identifiers that declare a name.
+    pub bindings: HashSet<usize>,
+    /// Identifiers a binding pattern names but that read rather than declare: the type the pattern
+    /// matches against, which is a direct child just as the names it introduces are. A query cannot
+    /// say "every child but this one", so this overrides `bindings`.
+    pub references: HashSet<usize>,
+    /// Callees already recorded through the call expression itself.
+    pub call_targets: HashSet<usize>,
+}
+
+pub fn roles(source_code: &str, root_node: Node) -> Result<Roles, String> {
+    Ok(Roles {
+        bindings: query::captured_nodes(QUERY, source_code, root_node, "binding")?,
+        references: query::captured_nodes(QUERY, source_code, root_node, "reference")?,
+        call_targets: query::captured_nodes(QUERY, source_code, root_node, "call_target")?,
+    })
 }

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use tree_sitter::Node;
 
 use super::format_string;
@@ -490,20 +489,15 @@ impl RustDefinitionExtractor {
 
 /// Rust-specific usage extractor
 pub struct RustUsageExtractor {
-    bindings: HashSet<usize>,
-    references: HashSet<usize>,
+    roles: super::binding_queries::Roles,
 }
 
 impl RustUsageExtractor {
     /// Fails if the binding query does not compile, which is a bug in the `.scm` file rather than
     /// anything about the source being analyzed.
     pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
-        let (bindings, references) =
-            super::binding_queries::bindings_and_references(source_code, root_node)?;
-
         Ok(Self {
-            bindings,
-            references,
+            roles: super::binding_queries::roles(source_code, root_node)?,
         })
     }
 }
@@ -524,7 +518,6 @@ impl NodeUsageExtractor for RustUsageExtractor {
                 // and not the function name part of a call_expression (to avoid duplication)
                 if self.is_identifier_in_definition_context(node)
                     || self.is_function_name_in_call_expression(node)
-                    || self.is_identifier_part_of_field_access(node, source)
                 {
                     None
                 } else if self.is_identifier_in_type_context(node) {
@@ -611,46 +604,18 @@ impl RustUsageExtractor {
     /// The patterns live in `queries/rust/bindings.scm`; a reference capture wins, which is how the
     /// type a pattern matches against stays a usage while the names it introduces do not.
     fn is_identifier_in_definition_context(&self, node: Node) -> bool {
-        self.bindings.contains(&node.id()) && !self.references.contains(&node.id())
+        self.roles.bindings.contains(&node.id()) && !self.roles.references.contains(&node.id())
     }
 
+    /// Whether the call expression around this identifier already records it.
     fn is_function_name_in_call_expression(&self, node: Node) -> bool {
-        let mut current = node.parent();
-        while let Some(parent) = current {
-            match parent.kind() {
-                "call_expression" => {
-                    // For simple function calls, check if this is directly the function name
-                    if let Some(function_node) = parent.child(0) {
-                        if function_node.id() == node.id() {
-                            return true;
-                        }
-                    }
-                    return false;
-                }
-                "scoped_identifier" => {
-                    // For qualified calls (e.g., HashMap::new), continue checking if this scoped_identifier
-                    // is the function part of a call_expression, but don't exclude path components
-                    current = parent.parent();
-                    continue;
-                }
-                _ => current = parent.parent(),
-            }
-        }
-        false
+        self.roles.call_targets.contains(&node.id())
     }
 
-    fn is_identifier_part_of_field_access(&self, node: Node, _source_code: &str) -> bool {
-        // Check if this identifier is the field part of a field_expression
-        if let Some(parent) = node.parent() {
-            if parent.kind() == "field_expression" {
-                if let Some(field_node) = parent.child_by_field_name("field") {
-                    return node.id() == field_node.id();
-                }
-            }
-        }
-        false
-    }
-
+    /// Whether this identifier sits anywhere inside a `use` tree.
+    ///
+    /// Stays here rather than moving to the query file: an ancestor at any depth is not a shape a
+    /// query states, and enumerating the depths a path can nest to would be worse than the walk.
     fn is_identifier_in_type_context(&self, node: Node) -> bool {
         let mut current = node.parent();
         while let Some(parent) = current {

--- a/crates/core/tests/unit/query/query_files_tests.rs
+++ b/crates/core/tests/unit/query/query_files_tests.rs
@@ -75,7 +75,7 @@ fn the_rust_binding_query_compiles_and_tells_a_binding_from_a_reference() {
 
     assert!(edges.contains(&(4, 1, "Meters")), "{edges:?}");
     assert!(edges.contains(&(5, 4, "value")), "{edges:?}");
-    let _ = rust::binding_queries::bindings_and_references;
+    let _ = rust::binding_queries::roles;
 }
 
 #[test]

--- a/docs/development/queries.md
+++ b/docs/development/queries.md
@@ -47,6 +47,8 @@ A query describes shape. When classifying needs more than shape, the extractor k
 - `let` patterns need their bindings told apart from the type they match, and a path component from
   a binding
 - format string captures do not exist as nodes at all and are parsed out of the literal
+- "sits anywhere inside a `use` tree" is an ancestor at any depth, and enumerating the depths a path
+  can nest to would be worse than the walk it replaces
 
 The extractor asks the query **first** and falls through to its arms only when nothing was captured.
 That ordering matters: a `const_item`'s name is an `identifier`, and the `identifier` arm would


### PR DESCRIPTION
Part of #170, following #227 and #228.

## `is_function_name_in_call_expression` → a query

It walked up through arbitrary parents to ask whether the identifier was a call expression's first child. That is `function:`, stated directly:

```scheme
(call_expression function: (identifier) @call_target)
```

A qualified callee such as `HashMap::new` is deliberately absent — its path components are references worth recording. The walk said that in a comment; the pattern says it by omission.

## `is_identifier_part_of_field_access` → deleted

It asked whether an identifier is the `field:` of a `field_expression`. Per `node-types.json` that field holds only `field_identifier` or `integer_literal`, and the function was consulted for `identifier` nodes only — so it always returned false. Deleted rather than migrated.

## `is_identifier_in_type_context` → stays

"Sits anywhere inside a `use` tree" is an ancestor at any depth, which is not a shape a query states; enumerating the depths a path can nest to would be worse than the walk. Now says so in a comment, and the docs list it beside the other cases that stay in the extractor.

## Verification

- accuracy `454 / 454`, precision 1.000, recall 1.000 — **identical to the recorded baseline**
- `cargo test --workspace` green, no snapshot changes
- `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

`rust_node_extractors.rs` 1042 → 1007 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)