### PR TITLE
refactor: move the property identifier check to a query, and drop arms the grammar cannot produce

### DIFF
--- a/crates/core/queries/typescript/bindings.scm
+++ b/crates/core/queries/typescript/bindings.scm
@@ -28,6 +28,21 @@
 ; `{ key: renamed }` binds `renamed` and reads `key`.
 (pair_pattern value: (identifier) @binding)
 
+; A member declaration's own name. Left as a usage it resolved to any same-named member of another
+; interface, and since that member's declaration did the same, the two invented a cycle.
+(public_field_definition name: [(property_identifier) (private_property_identifier)] @binding)
+(property_signature name: [(property_identifier) (private_property_identifier)] @binding)
+(method_signature name: [(property_identifier) (private_property_identifier)] @binding)
+(abstract_method_signature name: [(property_identifier) (private_property_identifier)] @binding)
+(method_definition name: [(property_identifier) (private_property_identifier)] @binding)
+(enum_body name: (property_identifier) @binding)
+
+; An object literal's key, or a pattern's, references no declared member: TypeScript is structurally
+; typed, so `{ x: 1 }` is a self-contained value, and the type it satisfies is usually declared in
+; another file. See "Object shapes" in crates/accuracy/README.md.
+(pair key: [(property_identifier) (private_property_identifier)] @shape_key)
+(pair_pattern key: [(property_identifier) (private_property_identifier)] @shape_key)
+
 ; Not a binding, but not counted here either: the call expression itself is extracted as the usage,
 ; so counting its callee again would record the same reference twice.
 (call_expression function: (identifier) @call_target)

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -83,10 +83,6 @@ impl NodeDefinitionExtractor for RustDefinitionExtractor {
                 .extract_metavariable_definition(node, scope, source)
                 .into_iter()
                 .collect(),
-            "constrained_type_parameter" => self
-                .extract_constrained_type_parameter_definition(node, scope, source)
-                .into_iter()
-                .collect(),
             "type_parameters" => self.extract_type_parameters_definitions(node, scope, source),
             "identifier" => {
                 // Check if this identifier is in a definition context
@@ -311,29 +307,6 @@ impl RustDefinitionExtractor {
         } else {
             None
         }
-    }
-
-    fn extract_constrained_type_parameter_definition(
-        &self,
-        node: Node,
-        scope: ScopeId,
-        source: &str,
-    ) -> Option<Definition> {
-        if let Some(first_child) = node.child(0) {
-            if first_child.kind() == "type_identifier" {
-                let name_text = first_child.utf8_text(source.as_bytes()).ok()?;
-
-                return Some(Definition {
-                    name: name_text.to_string(),
-                    definition_type: DefinitionType::TypeDefinition,
-                    position: Position::from_node(&first_child),
-                    scope_id: Some(scope),
-                    accessibility: None, // Will be set by ASTScopeTraverser to ScopeLocal
-                    is_hoisted: Some(false),
-                });
-            }
-        }
-        None
     }
 
     #[allow(dead_code)]

--- a/crates/core/src/languages/typescript/binding_queries.rs
+++ b/crates/core/src/languages/typescript/binding_queries.rs
@@ -5,16 +5,40 @@ use tree_sitter::Node;
 /// Identifiers that bind a name rather than reference one.
 const QUERY: &str = include_str!("../../../queries/typescript/bindings.scm");
 
-/// The identifiers the query calls bindings, and the callees it says are already counted.
+/// What the query says about each identifier it captures.
 ///
-/// Both come from one file because the extractor asks one question of it — whether this identifier
-/// is a reference worth recording — and the two reasons it may not be sit side by side.
-pub fn bindings_and_call_targets(
-    source_code: &str,
-    root_node: Node,
-) -> Result<(HashSet<usize>, HashSet<usize>), String> {
-    Ok((
-        query::captured_nodes(QUERY, source_code, root_node, "binding")?,
-        query::captured_nodes(QUERY, source_code, root_node, "call_target")?,
-    ))
+/// One file because the extractor asks one question of it — whether this identifier is a reference
+/// worth recording — and the reasons it may not be sit side by side.
+pub struct Roles {
+    /// Identifiers that declare a name.
+    bindings: HashSet<usize>,
+    /// Callees already recorded through the call expression itself.
+    call_targets: HashSet<usize>,
+    /// Object literal and pattern keys, which reference no declared member.
+    shape_keys: HashSet<usize>,
+}
+
+pub fn roles(source_code: &str, root_node: Node) -> Result<Roles, String> {
+    Ok(Roles {
+        bindings: query::captured_nodes(QUERY, source_code, root_node, "binding")?,
+        call_targets: query::captured_nodes(QUERY, source_code, root_node, "call_target")?,
+        shape_keys: query::captured_nodes(QUERY, source_code, root_node, "shape_key")?,
+    })
+}
+
+impl Roles {
+    /// Whether this identifier declares a name.
+    pub fn declares(&self, node: Node) -> bool {
+        self.bindings.contains(&node.id())
+    }
+
+    /// Whether this identifier is a reference this extractor should record.
+    ///
+    /// A declaration is not, a callee is already recorded through its call expression, and a shape
+    /// key names no declared member.
+    pub fn reads(&self, node: Node) -> bool {
+        !self.declares(node)
+            && !self.call_targets.contains(&node.id())
+            && !self.shape_keys.contains(&node.id())
+    }
 }

--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use tree_sitter::Node;
 
 use crate::models::{
@@ -394,20 +393,15 @@ impl TypeScriptDefinitionExtractor {
 
 /// TypeScript-specific usage extractor
 pub struct TypeScriptUsageExtractor {
-    bindings: HashSet<usize>,
-    call_targets: HashSet<usize>,
+    roles: super::binding_queries::Roles,
 }
 
 impl TypeScriptUsageExtractor {
     /// Fails if the binding query does not compile, which is a bug in the `.scm` file rather than
     /// anything about the source being analyzed.
     pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
-        let (bindings, call_targets) =
-            super::binding_queries::bindings_and_call_targets(source_code, root_node)?;
-
         Ok(Self {
-            bindings,
-            call_targets,
+            roles: super::binding_queries::roles(source_code, root_node)?,
         })
     }
 }
@@ -452,7 +446,7 @@ impl TypeScriptUsageExtractor {
     ///
     /// The patterns live in `queries/typescript/bindings.scm`.
     fn is_usage_context(&self, node: Node) -> bool {
-        !self.bindings.contains(&node.id()) && !self.call_targets.contains(&node.id())
+        self.roles.reads(node)
     }
 
     fn extract_identifier_usage(&self, node: Node, scope: ScopeId, source: &str) -> Option<Usage> {
@@ -546,61 +540,17 @@ impl TypeScriptUsageExtractor {
         })
     }
 
+    /// A member read through a receiver, unless this occurrence declares the member instead.
+    ///
+    /// Which occurrences declare rather than read is stated in `queries/typescript/bindings.scm`.
     fn extract_property_identifier_usage(
         &self,
         node: Node,
         scope: ScopeId,
         source: &str,
     ) -> Option<Usage> {
-        // Check if this property_identifier is in a definition context
-        if let Some(parent) = node.parent() {
-            match parent.kind() {
-                "pair" | "pair_pattern" => {
-                    // An object literal's key, or a pattern's, does not reference a declared
-                    // member. TypeScript is
-                    // structurally typed, so `{ x: 1 }` is a self-contained value rather than a
-                    // reference to some `x` declared elsewhere — and the type it satisfies is
-                    // usually declared in another file, which single-file analysis cannot see. Any
-                    // same-file member of the same name is a coincidence.
-                    //
-                    // The coupling to a declared type is already recorded through the annotation
-                    // that names it, as in `const p: Point = { x: 1 }`.
-                    if let Some(key_field) = parent.child_by_field_name("key") {
-                        if node.id() == key_field.id() {
-                            return None;
-                        }
-                    }
-                }
-                "enum_body" => {
-                    // Property identifiers in enum bodies are definitions, not usage
-                    return None;
-                }
-                // A member declaration is a definition. Left as a usage it resolved to any
-                // same-named member of another interface, and since that member's own declaration
-                // did the same, the two invented a cycle between themselves.
-                "public_field_definition"
-                | "private_field_definition"
-                | "field_definition"
-                | "property_signature"
-                | "method_signature"
-                | "abstract_method_signature" => {
-                    // Property identifiers in field definitions are definitions, not usage
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        if node.id() == name_field.id() {
-                            return None;
-                        }
-                    }
-                }
-                "method_definition" => {
-                    // Property identifiers in method definitions (method names) are definitions, not usage
-                    if let Some(name_field) = parent.child_by_field_name("name") {
-                        if node.id() == name_field.id() {
-                            return None;
-                        }
-                    }
-                }
-                _ => {}
-            }
+        if !self.roles.reads(node) {
+            return None;
         }
 
         // Property identifiers (like the "x" in "obj.x") should be treated as field expressions
@@ -617,6 +567,6 @@ impl TypeScriptUsageExtractor {
 
     /// Whether this type identifier is the name a declaration introduces.
     fn is_type_identifier_in_definition_context(&self, node: Node) -> bool {
-        self.bindings.contains(&node.id())
+        self.roles.declares(node)
     }
 }

--- a/crates/core/tests/unit/query/query_files_tests.rs
+++ b/crates/core/tests/unit/query/query_files_tests.rs
@@ -97,5 +97,5 @@ fn the_typescript_binding_query_compiles_and_finds_a_renaming_binding() {
             "{language:?}: {edges:?}"
         );
     }
-    let _ = typescript::binding_queries::bindings_and_call_targets;
+    let _ = typescript::binding_queries::roles;
 }

--- a/docs/development/queries.md
+++ b/docs/development/queries.md
@@ -131,6 +131,13 @@ TypeScript declaration missing.
 `crates/core/tests/unit/query/query_files_tests.rs` asserts each file compiles against its grammar,
 including TSX, which is a separate grammar from TypeScript.
 
+A hand-written `match node.kind()` has no such check: an arm naming a node the grammar does not have
+compiles, runs, and never matches. Checking the arms against `node-types.json` is what found
+`constrained_type_parameter`, `field_definition` and `private_field_definition` — three arms and the
+function behind one of them, all unreachable. The same sweep over `child_by_field_name` came back
+clean. It is worth re-running after a grammar upgrade, since that is how such an arm becomes dead in
+the first place.
+
 ### Adding a language
 
 1. Write `crates/core/queries/<language>/definitions.scm`


### PR DESCRIPTION
Part of #170, following #227, #228 and #229.

## The property identifier path

`extract_property_identifier_usage` dispatched on the parent kind to decide whether a member occurrence declares or reads. Both reasons it may not be a reference now sit in `bindings.scm`:

- `@binding` — a member declaration's own name (field, property signature, method, enum member)
- `@shape_key` — an object literal or pattern key, which references no declared member at all

They are captured separately because the reasons differ: the second is the object-shape decision recorded in `crates/accuracy/README.md`, not a declaration. `Roles::reads` answers all of it in one predicate.

The enum case stays exactly as narrow as it was — `enum_body`'s `name:` field, not `enum_assignment`'s, so `B` in `enum E { B = 2 }` is still read as a reference.

## Three arms the grammar cannot produce

Checking every `match node.kind()` arm in both language modules against `node-types.json`:

| Arm | Grammar says |
| --- | --- |
| `constrained_type_parameter` | absent from tree-sitter-rust 0.24 — takes `extract_constrained_type_parameter_definition` with it |
| `field_definition` | absent from both TypeScript grammars |
| `private_field_definition` | absent — the node is `public_field_definition`, whose `name:` may be a `private_property_identifier` |

They compiled, ran, and never matched. The same sweep over `child_by_field_name` came back clean.

This is the failure mode a query file does not have: a `.scm` naming a nonexistent node fails to compile and the tests catch it, which is how #222 was found. A `match` arm naming one is silent, so the docs now say to re-run the sweep after a grammar upgrade — that is how an arm becomes dead in the first place.

## Verification

- accuracy `454 / 454`, precision 1.000, recall 1.000 — **identical to the recorded baseline**
- `cargo test --workspace` green, no snapshot changes
- `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

`typescript_node_extractors.rs` 622 → 572, `rust_node_extractors.rs` 1007 → 980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved TypeScript code analysis by more accurately distinguishing declarations, references, calls, and object or pattern keys.
  * Improved recognition of bindings in TypeScript properties, methods, enum members, and related constructs.
  * Refined Rust analysis to avoid incorrectly treating constrained type parameters as standalone definitions.
* **Documentation**
  * Added guidance for validating language query rules and detecting unsupported or unreachable syntax patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->