### PR TITLE
fix(typescript): see through a wrapped receiver, and read a type stated at the access

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -337,9 +337,9 @@
       "duplicates": 1
     },
     "typescript/member_access.ts": {
-      "expected": 12,
-      "detected": 12,
-      "correct": 12,
+      "expected": 24,
+      "detected": 24,
+      "correct": 24,
       "missing": 0,
       "spurious": 0,
       "duplicates": 1
@@ -378,9 +378,9 @@
     }
   },
   "total": {
-    "expected": 454,
-    "detected": 454,
-    "correct": 454,
+    "expected": 466,
+    "detected": 466,
+    "correct": 466,
     "missing": 0,
     "spurious": 0,
     "duplicates": 26

--- a/crates/accuracy/fixtures/typescript/member_access.ts
+++ b/crates/accuracy/fixtures/typescript/member_access.ts
@@ -28,3 +28,13 @@ function fromVariable(): number {
 function fromUnannotated(untyped: Reader | Writer): string { //~ depends: Reader@7, Writer@11
     return String(untyped.label); //~ depends: untyped@28, label@8, label@12
 }
+
+function throughWrappers(maybe?: Reader): void { //~ depends: Reader@7
+    void maybe?.label; //~ depends: maybe@32, label@8
+    void maybe!.label; //~ depends: maybe@32, label@8
+    void (maybe).label; //~ depends: maybe@32, label@8
+}
+
+function statedAtTheAccess(unknownType: Reader | Writer): void { //~ depends: Reader@7, Writer@11
+    void (unknownType as Writer).label; //~ depends: unknownType@38, Writer@11, label@12
+}

--- a/crates/core/queries/typescript/member_accesses.scm
+++ b/crates/core/queries/typescript/member_accesses.scm
@@ -1,13 +1,9 @@
 ; What each `receiver.member` reads from, keyed by the member's position, since a usage carries its
 ; position and only the member's own name.
 ;
-; A chained access such as `a.b.c` is deliberately unmatched: its receiver is an expression rather
-; than a name, so the file does not state its type.
+; The receiver is captured whole rather than as a name: it may be wearing a wrapper (`(a)`, `a!`) or
+; state its own type (`a as First`), and what it is gets decided in Rust.
 
 (member_expression
-  object: (identifier) @receiver
-  property: (property_identifier) @accessed)
-
-(member_expression
-  object: (this) @receiver
+  object: (_) @receiver
   property: (property_identifier) @accessed)

--- a/crates/core/src/languages/typescript/dependency_resolver/receiver_narrowing.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/receiver_narrowing.rs
@@ -3,8 +3,8 @@
 //! Two types may declare a member of the same name, and matching on the name alone links an access
 //! to both — inventing a relationship with a type the code never mentions. The receiver's type is
 //! what tells them apart, and a single file knows it only where it is written down: an annotated
-//! parameter or variable, or `this` inside a class. Where it is not written down, nothing is
-//! claimed.
+//! parameter or variable, an `as` at the access itself, or `this` inside a class. Where it is not
+//! written down, nothing is claimed.
 
 use crate::models::{Definition, Usage};
 use crate::query::{self, NamedSpan};
@@ -20,13 +20,15 @@ const MEMBER_ACCESSES: &str = include_str!("../../../../queries/typescript/membe
 /// What each member access can be narrowed to, read off the file once.
 pub struct ReceiverNarrowing {
     owner_by_member_position: HashMap<(usize, usize), String>,
-    types_by_binding: HashMap<String, Vec<String>>,
-    class_spans: Vec<NamedSpan>,
-    receiver_by_access_position: HashMap<(usize, usize), String>,
+    /// The types the receiver of each access may have, keyed by the accessed member's position,
+    /// which is what a `Usage` carries.
+    receiver_types_by_access: HashMap<(usize, usize), Vec<String>>,
 }
 
 impl ReceiverNarrowing {
     pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
+        let annotations = Annotations::read(source_code, root_node)?;
+
         Ok(Self {
             owner_by_member_position: query::text_by_position(
                 MEMBER_OWNERS,
@@ -35,35 +37,24 @@ impl ReceiverNarrowing {
                 "owner",
                 "member",
             )?,
-            types_by_binding: query::map_pairs(
-                RECEIVER_TYPES,
-                source_code,
-                root_node,
-                "binding",
-                "annotated",
-                |binding, annotation| {
-                    Some((
-                        binding.utf8_text(source_code.as_bytes()).ok()?.to_string(),
-                        annotated_type_names(&annotation, source_code),
-                    ))
-                },
-            )?
-            .into_iter()
-            .collect(),
-            class_spans: query::text_by_span(
-                ENCLOSING_CLASSES,
-                source_code,
-                root_node,
-                "owner",
-                "body",
-            )?,
-            receiver_by_access_position: query::text_by_position(
+            receiver_types_by_access: query::map_pairs(
                 MEMBER_ACCESSES,
                 source_code,
                 root_node,
                 "receiver",
                 "accessed",
-            )?,
+                |receiver, accessed| {
+                    Some((
+                        (
+                            accessed.start_position().row + 1,
+                            accessed.start_position().column + 1,
+                        ),
+                        annotations.types_of(receiver, source_code)?,
+                    ))
+                },
+            )?
+            .into_iter()
+            .collect(),
         })
     }
 
@@ -81,7 +72,10 @@ impl ReceiverNarrowing {
             return candidates;
         }
 
-        let Some(owners) = self.receiver_types(usage) else {
+        let Some(owners) = self
+            .receiver_types_by_access
+            .get(&(usage.position.start_line, usage.position.start_column))
+        else {
             return Vec::new();
         };
 
@@ -94,18 +88,71 @@ impl ReceiverNarrowing {
             .collect()
     }
 
-    /// The types of what the access reads from, where the file states them. A union states several,
-    /// and the member may be declared by any of them.
-    ///
-    /// A usage names only the member, so the receiver is found by the position the two share.
-    fn receiver_types(&self, usage: &Usage) -> Option<Vec<String>> {
-        let position = (usage.position.start_line, usage.position.start_column);
+    fn owner_of(&self, definition: &Definition) -> Option<&String> {
+        self.owner_by_member_position.get(&(
+            definition.position.start_line,
+            definition.position.start_column,
+        ))
+    }
+}
 
-        match self.receiver_by_access_position.get(&position)?.as_str() {
+/// Where the file states a type, which is the only way to know what a receiver is.
+struct Annotations {
+    types_by_binding: HashMap<String, Vec<String>>,
+    class_spans: Vec<NamedSpan>,
+}
+
+impl Annotations {
+    fn read(source_code: &str, root_node: Node) -> Result<Self, String> {
+        Ok(Self {
+            types_by_binding: query::map_pairs(
+                RECEIVER_TYPES,
+                source_code,
+                root_node,
+                "binding",
+                "annotated",
+                |binding, annotation| {
+                    Some((
+                        binding.utf8_text(source_code.as_bytes()).ok()?.to_string(),
+                        type_names(&annotation, source_code),
+                    ))
+                },
+            )?
+            .into_iter()
+            .collect(),
+            class_spans: query::text_by_span(
+                ENCLOSING_CLASSES,
+                source_code,
+                root_node,
+                "owner",
+                "body",
+            )?,
+        })
+    }
+
+    /// The types this receiver expression may have. A union states several, and the member may be
+    /// declared by any of them.
+    fn types_of(&self, receiver: Node, source_code: &str) -> Option<Vec<String>> {
+        match receiver.kind() {
+            "identifier" => self
+                .types_by_binding
+                .get(receiver.utf8_text(source_code.as_bytes()).ok()?)
+                .cloned(),
             "this" => self
-                .enclosing_class(usage.position.start_line)
+                .enclosing_class(receiver.start_position().row + 1)
                 .map(|class_name| vec![class_name]),
-            binding => self.types_by_binding.get(binding).cloned(),
+            // `a as First` states the type at the access itself, which is as good as an annotation
+            // on the binding and better than nothing when the binding has none.
+            "as_expression" | "satisfies_expression" => {
+                Some(type_names(&receiver.named_child(1)?, source_code))
+            }
+            // `(a)`, `a!` and `-a` are the same receiver wearing a wrapper.
+            "parenthesized_expression" | "non_null_expression" | "unary_expression" => {
+                self.types_of(receiver.named_child(0)?, source_code)
+            }
+            // A chained `a.b.c` or a call's result is an expression whose type the file does not
+            // state, so nothing is claimed for it.
+            _ => None,
         }
     }
 
@@ -118,20 +165,13 @@ impl ReceiverNarrowing {
             .min_by_key(|(_, (start, end))| end - start)
             .map(|(owner, _)| owner.clone())
     }
-
-    fn owner_of(&self, definition: &Definition) -> Option<&String> {
-        self.owner_by_member_position.get(&(
-            definition.position.start_line,
-            definition.position.start_column,
-        ))
-    }
 }
 
-/// The type names an annotation states.
+/// The type names a type expression states.
 ///
 /// Type arguments are not descended into: `Wrapper<Reader>` states `Wrapper`, and its members are
 /// the ones a receiver of that type reaches.
-fn annotated_type_names(node: &Node, source_code: &str) -> Vec<String> {
+fn type_names(node: &Node, source_code: &str) -> Vec<String> {
     if node.kind() == "type_identifier" {
         return node
             .utf8_text(source_code.as_bytes())
@@ -142,6 +182,6 @@ fn annotated_type_names(node: &Node, source_code: &str) -> Vec<String> {
     (0..node.child_count())
         .filter_map(|index| node.child(index))
         .filter(|child| child.kind() != "type_arguments")
-        .flat_map(|child| annotated_type_names(&child, source_code))
+        .flat_map(|child| type_names(&child, source_code))
         .collect()
 }


### PR DESCRIPTION
Found by probing the code #226 had just landed, against forms no fixture reached.

`a!.label` produced **no member edge at all**. The receiver was matched only as a bare identifier, so a non-null assertion left its type unknown — and an unknown type with two same-named members yields nothing by design (#213). The wrapper was hiding a type the file states plainly one token away.

| Receiver | Before | After |
| --- | --- | --- |
| `a.label` | `First.label` | unchanged |
| `a?.label` | `First.label` | unchanged — `object:` is still the identifier |
| `a!.label` | **nothing** | `First.label` |
| `(a).label` | **nothing** | `First.label` |
| `(a as Writer).label` | nothing | `Writer.label` |

The receiver is now captured whole and resolved in Rust rather than matched as a name, which is also what lets `as` be read at the access itself — strictly better than the binding's annotation when the binding has none, as for a union-typed parameter.

A chained `a.b.c` and a call's result stay unknown, since the file does not state their type. That is the same deliberate silence as before.

## Verification

- accuracy `466 / 466`, precision 1.000, recall 1.000; `member_access.ts` grows from 12 to 24 expectations covering `?.`, `!`, a parenthesis and `as`
- every other fixture unchanged
- `cargo test --workspace` green, no snapshot changes, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

Another instance of the pattern recorded in `crates/accuracy/README.md`: a perfect score meant the fixtures did not reach the bug. This one was in code three PRs old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)