### PR TITLE
fix(typescript): stop reading a declaration's own name as a reference

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -280,6 +280,14 @@
       "spurious": 0,
       "duplicates": 2
     },
+    "typescript/declaration_names.ts": {
+      "expected": 7,
+      "detected": 7,
+      "correct": 7,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/destructuring.ts": {
       "expected": 11,
       "detected": 11,
@@ -378,9 +386,9 @@
     }
   },
   "total": {
-    "expected": 466,
-    "detected": 466,
-    "correct": 466,
+    "expected": 473,
+    "detected": 473,
+    "correct": 473,
     "missing": 0,
     "spurious": 0,
     "duplicates": 26

--- a/crates/accuracy/fixtures/typescript/declaration_names.ts
+++ b/crates/accuracy/fixtures/typescript/declaration_names.ts
@@ -1,0 +1,31 @@
+// Declaration forms whose own name is not a use of itself.
+//
+// Each name below collides deliberately with a top-level declaration of the same name. A name that
+// declares must not resolve to the colliding one; see #233.
+
+function inner(): number {
+    return 0;
+}
+
+class Inner {
+    tag = "outer";
+}
+
+function* stream(): Iterable<number> {
+    yield 1;
+}
+
+const asExpression = function inner(): number {
+    return 1;
+};
+
+const classExpression = class Inner {
+    tag = "inner";
+};
+
+function overloaded(x: string): string;
+function overloaded(x: string): string {
+    return x; //~ depends: x@27
+}
+
+const consumed = [inner(), new Inner(), stream(), asExpression, classExpression, overloaded("a")]; //~ depends: inner@6, Inner@10, stream@14, asExpression@18, classExpression@22, overloaded@27

--- a/crates/core/queries/typescript/bindings.scm
+++ b/crates/core/queries/typescript/bindings.scm
@@ -6,10 +6,25 @@
 
 ; A declaration's own name is not a use of itself.
 (function_declaration name: (identifier) @binding)
+(generator_function_declaration name: (identifier) @binding)
 (enum_declaration name: (identifier) @binding)
 (internal_module name: (identifier) @binding)
+(module name: (identifier) @binding)
 (variable_declarator name: (identifier) @binding)
 (import_specifier name: (identifier) @binding)
+
+; An overload signature and its implementation are one function declared twice, not a reference
+; from one to the other.
+(function_signature name: (identifier) @binding)
+
+; A function or class expression's name is bound inside its own body; it names nothing outside.
+(function_expression name: (identifier) @binding)
+(generator_function name: (identifier) @binding)
+(class name: (type_identifier) @binding)
+
+; `[key: string]: T` and `[K in keyof T]` each introduce the name they then use.
+(index_signature name: (identifier) @binding)
+(mapped_type_clause name: (type_identifier) @binding)
 
 (interface_declaration name: (type_identifier) @binding)
 (type_alias_declaration name: (type_identifier) @binding)
@@ -36,6 +51,7 @@
 (abstract_method_signature name: [(property_identifier) (private_property_identifier)] @binding)
 (method_definition name: [(property_identifier) (private_property_identifier)] @binding)
 (enum_body name: (property_identifier) @binding)
+(enum_assignment name: [(property_identifier) (private_property_identifier)] @binding)
 
 ; An object literal's key, or a pattern's, references no declared member: TypeScript is structurally
 ; typed, so `{ x: 1 }` is a self-contained value, and the type it satisfies is usually declared in

--- a/crates/core/queries/typescript/definitions.scm
+++ b/crates/core/queries/typescript/definitions.scm
@@ -17,6 +17,7 @@
 (internal_module name: (identifier) @definition.namespace)
 
 (function_declaration name: (identifier) @definition.function)
+(generator_function_declaration name: (identifier) @definition.function)
 
 (method_definition name: (property_identifier) @definition.method)
 (method_definition name: (private_property_identifier) @definition.method)

--- a/crates/test-generator/tests/snapshots/ts/test_generated_generator_function_declaration.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_generator_function_declaration.snap
@@ -23,10 +23,11 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition { position: { 1:11 to 1:18 }, name: "testFn2", definition_type: FunctionDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+    ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:11 to 1:18 }, name: "testFn2", kind: Identifier, context: None },
         Usage { position: { 1:29 to 1:35 }, name: "value9", kind: Identifier, context: None },
     ],
     analysis_metadata: AnalysisMetadata {

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_generator_function_declaration.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_generator_function_declaration.snap
@@ -23,10 +23,11 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition { position: { 1:11 to 1:18 }, name: "testFn2", definition_type: FunctionDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+    ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:11 to 1:18 }, name: "testFn2", kind: Identifier, context: None },
         Usage { position: { 1:29 to 1:35 }, name: "value9", kind: Identifier, context: None },
     ],
     analysis_metadata: AnalysisMetadata {


### PR DESCRIPTION
close: #233

Nine declaration forms were missing from `bindings.scm`, so their names resolved to whatever unrelated declaration happened to share the name:

```typescript
function inner(): number { return 0; }              // L1
const a = function inner(): number { return 1; };   // L5  ->  5 -> 1 inner, invented
```

`inner` in a function expression is bound inside its own body; it names nothing outside. Same for a class expression, and an overload signature was doing it to its own implementation (`1 -> 2 dup`).

## What was added

| Node | Form |
| --- | --- |
| `function_signature` | an overload declaration |
| `function_expression`, `generator_function` | `const f = function named() {}` |
| `generator_function_declaration` | `function* named() {}` |
| `class` | `const C = class Named {}` |
| `module` | ambient `module Foo {}` |
| `index_signature`, `mapped_type_clause` | `[key: string]: T`, `[K in keyof T]` — each introduces the name it then uses |
| `enum_assignment` | `enum E { B = 2 }` — `B` declares; #230 had deliberately left this as it was |

A generator declaration was also absent from `definitions.scm`, so `gen()` had nothing to resolve to at all. It is a function declaration with a `*`, and now says so — one more edge found rather than one fewer.

## How they were found

By listing every grammar node with a `name:` field that can hold an `identifier`, `type_identifier` or `property_identifier`, and diffing against what the query files capture — the same `node-types.json` sweep that found the dead arms in #230, run in the other direction.

The sweep also confirms what is correctly absent: `export_specifier` names a local declaration, `type_predicate`'s `x is Foo` names the parameter, `generic_type` and `nested_type_identifier` are uses, and a `jsx_*_element` name references its component.

## Verification

- accuracy `473 / 473`, precision 1.000, recall 1.000
- `declaration_names.ts` adds 7 expectations. Every name in it collides deliberately with a top-level declaration, so the false edge is what the harness reports if it returns — without the collision the bug is invisible, which is why 466 expectations at precision 1.000 did not reach it
- two snapshots change: the generator's name moves from a usage it never was to the definition it is
- `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

Filed alongside: #234 (a const generic parameter produces no definition) and #235 (reading a getter resolves to the setter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)