### PR TITLE
fix(rust): give a const generic parameter a definition

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -73,9 +73,9 @@
       "duplicates": 0
     },
     "rust/generics.rs": {
-      "expected": 10,
-      "detected": 10,
-      "correct": 10,
+      "expected": 13,
+      "detected": 13,
+      "correct": 13,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -386,9 +386,9 @@
     }
   },
   "total": {
-    "expected": 473,
-    "detected": 473,
-    "correct": 473,
+    "expected": 476,
+    "detected": 476,
+    "correct": 476,
     "missing": 0,
     "spurious": 0,
     "duplicates": 26

--- a/crates/accuracy/fixtures/rust/generics.rs
+++ b/crates/accuracy/fixtures/rust/generics.rs
@@ -22,3 +22,13 @@ fn main() {
     let s = Square { side: 2 }; //~ depends: Square@7, side@8
     let _ = largest(&[s]); //~ depends: largest@17, s@22
 }
+
+struct Buffer<const N: usize> {
+    data: [u8; N], //~ depends: N@26
+}
+
+impl<const N: usize> Buffer<N> { //~ depends: Buffer@26
+    fn capacity(&self) -> usize {
+        N //~ depends: N@30
+    }
+}

--- a/crates/core/queries/rust/bindings.scm
+++ b/crates/core/queries/rust/bindings.scm
@@ -28,6 +28,8 @@
 (call_expression function: (identifier) @call_target)
 
 (type_parameter name: (type_identifier) @binding)
+(const_parameter name: (identifier) @binding)
+(extern_crate_declaration name: (identifier) @binding)
 (lifetime (identifier) @binding)
 (bounded_type (type_identifier) @binding)
 

--- a/crates/core/queries/rust/definitions.scm
+++ b/crates/core/queries/rust/definitions.scm
@@ -14,6 +14,8 @@
 (type_item name: (type_identifier) @definition.type)
 (associated_type name: (type_identifier) @definition.type)
 (type_parameter name: (type_identifier) @definition.type)
+; A const generic declares a value, not a type, though it is written among the type parameters.
+(const_parameter name: (identifier) @definition.const)
 
 (mod_item name: (identifier) @definition.module)
 


### PR DESCRIPTION
close: #234

```rust
struct Buffer<const N: usize> {
    data: [u8; N],
}
```

`N` produced no definition, so the field had nothing to depend on — no edge at all. Renaming the parameter breaks the field, which is exactly the coupling this tool exists to record.

Now:

| Line | Edge |
| --- | --- |
| `data: [u8; N]` | → the struct's `N` |
| `impl<const N: usize> Buffer<N>` | → `Buffer` |
| `N` in a method body | → the **impl's own** `N`, not the struct's |

A const generic is captured as a const rather than a type: it declares a value, though it is written among the type parameters. Scope handling needed nothing new, since it is scoped exactly as a type parameter is — #215 settled that shape.

`extern_crate_declaration` joins `bindings.scm` at the same time; `extern crate serde;` binds `serde` locally, and it was the last Rust declaration form the `node-types.json` sweep listed as missing.

## Verification

- accuracy `476 / 476`, precision 1.000, recall 1.000; `rust/generics.rs` grows from 10 to 13 expectations
- every other fixture unchanged, no snapshot changes
- `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Rust code analysis now recognizes const generic parameters and their related definitions.
  - External crate declarations are better identified during usage analysis.
  - Added coverage for const-generic buffer types and capacity calculations.

- **Bug Fixes**
  - Improved accuracy for Rust generic code analysis, with updated validation metrics reflecting the additional detections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->