### PR TITLE
fix(typescript): reach the getter when reading and the setter when writing

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -248,6 +248,14 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "typescript/accessors.ts": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/async_functions.ts": {
       "expected": 6,
       "detected": 6,
@@ -386,9 +394,9 @@
     }
   },
   "total": {
-    "expected": 476,
-    "detected": 476,
-    "correct": 476,
+    "expected": 485,
+    "detected": 485,
+    "correct": 485,
     "missing": 0,
     "spurious": 0,
     "duplicates": 26

--- a/crates/accuracy/fixtures/typescript/accessors.ts
+++ b/crates/accuracy/fixtures/typescript/accessors.ts
@@ -1,0 +1,34 @@
+// A getter and a setter of the same name are one member declared in two places.
+//
+// The receiver's type cannot tell them apart, since both belong to the same class. Direction can:
+// reading reaches the getter, assigning reaches the setter. See #235.
+//
+// `+=` reads before it writes, so it reaches both; only the setter is recorded, because one usage
+// records one target. That cost is pinned below rather than left implicit.
+
+class Counter {
+    private stored = 0;
+
+    get value(): number {
+        return this.stored; //~ depends: stored@10
+    }
+
+    set value(next: number) {
+        this.stored = next; //~ depends: stored@10, next@16
+    }
+
+    read(): number {
+        return this.value; //~ depends: value@12
+    }
+
+    write(): void {
+        this.value = 5; //~ depends: value@16
+    }
+
+    bump(): void {
+        this.value += 1; //~ depends: value@16
+    }
+}
+
+const counter = new Counter(); //~ depends: Counter@9
+const observed = counter.value; //~ depends: counter@33, value@12

--- a/crates/core/queries/typescript/accessors.scm
+++ b/crates/core/queries/typescript/accessors.scm
@@ -1,0 +1,7 @@
+; Getters and setters, which declare one member in two places.
+;
+; Both are `method_definition`s of the same name, so only the keyword tells them apart — and which
+; one an access reaches depends on whether it reads or writes.
+
+(method_definition "get" name: (property_identifier) @getter)
+(method_definition "set" name: (property_identifier) @setter)

--- a/crates/core/queries/typescript/written_accesses.scm
+++ b/crates/core/queries/typescript/written_accesses.scm
@@ -1,0 +1,13 @@
+; Member accesses that write, and those that read before writing.
+;
+; `o.p = v` reaches a setter alone. `o.p += v` and `o.p++` read the old value first, so they reach
+; both accessors of a pair. Everything not captured here reads.
+
+(assignment_expression
+  left: (member_expression property: (property_identifier) @written))
+
+(augmented_assignment_expression
+  left: (member_expression property: (property_identifier) @modified))
+
+(update_expression
+  argument: (member_expression property: (property_identifier) @modified))

--- a/crates/core/src/languages/typescript/dependency_resolver/accessor_direction.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/accessor_direction.rs
@@ -1,0 +1,84 @@
+//! Choosing between a getter and a setter by what the access does.
+//!
+//! A getter and a setter of the same name are one member declared in two places, and the receiver's
+//! type cannot tell them apart — both belong to the same class. What tells them apart is direction:
+//! reading reaches the getter and assigning reaches the setter.
+//!
+//! `o.p += v` reads the old value before writing the new one, so it reaches both. Only the setter is
+//! recorded, because the resolver records one target per usage; the getter edge is the cost of that
+//! and is pinned as such in the fixtures.
+
+use crate::models::{Definition, Usage};
+use crate::query;
+use std::collections::HashSet;
+use tree_sitter::Node;
+
+const ACCESSORS: &str = include_str!("../../../../queries/typescript/accessors.scm");
+const WRITTEN_ACCESSES: &str = include_str!("../../../../queries/typescript/written_accesses.scm");
+
+type Positions = HashSet<(usize, usize)>;
+
+/// Which declarations are accessors, and which accesses write, read off the file once.
+pub struct AccessorDirection {
+    getters: Positions,
+    setters: Positions,
+    written: Positions,
+    modified: Positions,
+}
+
+impl AccessorDirection {
+    pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
+        Ok(Self {
+            getters: positions(ACCESSORS, source_code, root_node, "getter")?,
+            setters: positions(ACCESSORS, source_code, root_node, "setter")?,
+            written: positions(WRITTEN_ACCESSES, source_code, root_node, "written")?,
+            modified: positions(WRITTEN_ACCESSES, source_code, root_node, "modified")?,
+        })
+    }
+
+    /// Keep the accessor this access reaches.
+    ///
+    /// Only a getter and setter sharing a name are ambiguous in this way, so anything else is left
+    /// alone — including a lone accessor, which an access reaches whichever way it goes.
+    pub fn narrow<'a>(
+        &self,
+        usage: &Usage,
+        candidates: Vec<&'a Definition>,
+    ) -> Vec<&'a Definition> {
+        let position = (usage.position.start_line, usage.position.start_column);
+        if !self.is_accessor_pair(&candidates) {
+            return candidates;
+        }
+
+        let writes = self.written.contains(&position) || self.modified.contains(&position);
+        let unreached = if writes { &self.getters } else { &self.setters };
+
+        candidates
+            .into_iter()
+            .filter(|candidate| !unreached.contains(&position_of(candidate)))
+            .collect()
+    }
+
+    fn is_accessor_pair(&self, candidates: &[&Definition]) -> bool {
+        let positions = || candidates.iter().copied().map(position_of);
+
+        positions().any(|position| self.getters.contains(&position))
+            && positions().any(|position| self.setters.contains(&position))
+    }
+}
+
+fn positions(
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+    capture: &str,
+) -> Result<Positions, String> {
+    query::captured_positions(query_source, source_code, root_node, capture)
+}
+
+fn position_of(definition: &Definition) -> (usize, usize) {
+    (
+        definition.position.start_line,
+        definition.position.start_column,
+    )
+}

--- a/crates/core/src/languages/typescript/dependency_resolver/mod.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/mod.rs
@@ -1,3 +1,4 @@
+pub mod accessor_direction;
 pub mod interface_implementation_resolver;
 pub mod method_resolver;
 pub mod module_resolver;

--- a/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
@@ -5,6 +5,7 @@ use crate::models::{
 };
 use tree_sitter::Node;
 
+use super::accessor_direction::AccessorDirection;
 use super::method_resolver::MethodResolver;
 use super::module_resolver::ModuleResolver;
 use super::receiver_narrowing::ReceiverNarrowing;
@@ -237,10 +238,13 @@ impl DependencyResolverTrait for TypeScriptDependencyResolver {
         // Read off the file once rather than per usage: every member access asks the same questions
         // of it, and a malformed query must fail rather than quietly resolve nothing.
         let narrowing = ReceiverNarrowing::new(source_code, root_node)?;
+        let direction = AccessorDirection::new(source_code, root_node)?;
 
         let mut all_dependencies: Vec<Dependency> = usage_nodes
             .iter()
-            .flat_map(|usage| self.resolve_single_dependency(&narrowing, usage, definitions))
+            .flat_map(|usage| {
+                self.resolve_single_dependency(&narrowing, &direction, usage, definitions)
+            })
             .collect();
 
         // Add interface implementation dependencies (class method -> interface declaration), which
@@ -259,6 +263,7 @@ impl TypeScriptDependencyResolver {
     fn resolve_single_dependency(
         &self,
         narrowing: &ReceiverNarrowing,
+        direction: &AccessorDirection,
         usage_node: &Usage,
         definitions: &[Definition],
     ) -> Vec<Dependency> {
@@ -280,12 +285,16 @@ impl TypeScriptDependencyResolver {
             .filter(|def| def.name == usage_node.name)
             .collect();
 
-        let matching_definitions: Vec<&Definition> = all_matching_definitions
+        let accessible: Vec<&Definition> = all_matching_definitions
             .into_iter()
             .filter(|def| !Self::is_member_reached_by_name(usage_node, def))
             .filter(|def| self.is_accessible_basic(usage_node, def))
             .filter(|def| self.module_resolver.is_valid_dependency(usage_node, def))
             .collect();
+
+        // A getter and a setter share a name, so which one is reached is decided by whether this
+        // access reads or writes rather than by any preference among them.
+        let matching_definitions = direction.narrow(usage_node, accessible);
 
         // Apply TypeScript-specific preference logic
         let preferred_definition = if usage_node.kind == crate::models::UsageKind::TypeIdentifier {

--- a/crates/core/src/query/mod.rs
+++ b/crates/core/src/query/mod.rs
@@ -70,6 +70,33 @@ pub fn captured_nodes(
     Ok(roles.into_keys().collect())
 }
 
+/// The positions one capture name matches.
+///
+/// Positions rather than node ids, because both a `Definition` and a `Usage` carry a position and
+/// neither carries a node.
+pub fn captured_positions(
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+    capture: &str,
+) -> Result<HashSet<(usize, usize)>, String> {
+    let located = map_pairs(
+        query_source,
+        source_code,
+        root_node,
+        capture,
+        capture,
+        |node, _| {
+            Some((
+                node.start_position().row + 1,
+                node.start_position().column + 1,
+            ))
+        },
+    )?;
+
+    Ok(located.into_iter().collect())
+}
+
 /// What a captured name node declares.
 ///
 /// Both languages need the kind, and TypeScript needs hoisting as well — a class is visible before


### PR DESCRIPTION
close: #235

```typescript
get current(): number { return this.value; }     // L4
set current(v: number) { this.value = v; }       // L5

read(): number { return this.current; }          // L7  ->  L5, the setter
```

A getter and a setter of the same name are one member declared in two places. The receiver's type cannot tell them apart — both belong to the same class — so #213's narrowing left both and something downstream picked one. Direction is what distinguishes them:

| Access | Reaches |
| --- | --- |
| `this.current` | the **getter** |
| `this.current = 5` | the setter |
| `this.current += 1` | both; only the setter is recorded |
| a lone getter or setter | that one, either way |

`+=` reads the old value before writing the new one, so it genuinely reaches both. The resolver records one target per usage, so only the setter is recorded — now a stated choice rather than whichever candidate came last, and the missing getter edge is pinned as absent in the fixture rather than left implicit.

## Verification

- accuracy `485 / 485`, precision 1.000, recall 1.000
- `accessors.ts` adds 9 expectations: all three directions, from inside the class and from outside it. `counter.value` from outside reaches the getter, which needs the receiver-type narrowing and the direction working together
- every other fixture unchanged, no snapshot changes
- `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)