### PR TITLE
fix(typescript): treat a catch parameter and a for-of binding as declarations

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -360,6 +360,14 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "typescript/loop_and_catch_bindings.ts": {
+      "expected": 12,
+      "detected": 12,
+      "correct": 12,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/member_access.ts": {
       "expected": 24,
       "detected": 24,
@@ -402,9 +410,9 @@
     }
   },
   "total": {
-    "expected": 498,
-    "detected": 498,
-    "correct": 498,
+    "expected": 510,
+    "detected": 510,
+    "correct": 510,
     "missing": 0,
     "spurious": 0,
     "duplicates": 27

--- a/crates/accuracy/fixtures/typescript/loop_and_catch_bindings.ts
+++ b/crates/accuracy/fixtures/typescript/loop_and_catch_bindings.ts
@@ -1,0 +1,41 @@
+// Names introduced by a loop header or a catch clause.
+//
+// A `for` with `const`, `let` or `var` declares its variable; one without assigns to a binding that
+// already exists, so it reads instead. A catch parameter always declares.
+//
+// Each name below collides deliberately with an outer declaration, so a name read as a reference
+// when it declares would show up as an edge to the wrong line. See #241.
+
+const item = 100;
+let existing = 0;
+const failure = "outer";
+
+function declaring(values: number[]): number {
+    let total = 0;
+
+    for (const item of values) { //~ depends: values@13
+        total += item; //~ depends: total@14, item@16
+    }
+
+    for (const key in values) { //~ depends: values@13
+        total += Number(key); //~ depends: total@14, key@20
+    }
+
+    return total; //~ depends: total@14
+}
+
+function assigning(values: number[]): number {
+    for (existing of values) { //~ depends: existing@10, values@27
+        break;
+    }
+
+    return existing; //~ depends: existing@10
+}
+
+function catching(): string {
+    try {
+        return failure; //~ depends: failure@11
+    } catch (failure) {
+        return String(failure); //~ depends: failure@38
+    }
+}

--- a/crates/core/queries/typescript/bindings.scm
+++ b/crates/core/queries/typescript/bindings.scm
@@ -32,6 +32,12 @@
 (abstract_class_declaration name: (type_identifier) @binding)
 (type_parameter name: (type_identifier) @binding)
 
+; `catch (e)` declares `e`, and `for (const x of xs)` declares `x`. A `for` without `kind:` assigns
+; to a binding that already exists, so it reads rather than declares — which is why the field is
+; required rather than the shape alone.
+(catch_clause parameter: (identifier) @binding)
+(for_in_statement kind: _ left: (identifier) @binding)
+
 ; Names a pattern or parameter list introduces.
 (array_pattern (identifier) @binding)
 (rest_pattern (identifier) @binding)

--- a/crates/core/queries/typescript/definitions.scm
+++ b/crates/core/queries/typescript/definitions.scm
@@ -28,6 +28,11 @@
 (public_field_definition name: (property_identifier) @definition.property)
 (public_field_definition name: (private_property_identifier) @definition.property)
 
+; `catch (e)` and `for (const x of xs)` each declare a local. A `for` without `kind:` assigns to a
+; binding that already exists, so the field is required rather than the shape alone.
+(catch_clause parameter: (identifier) @definition.variable)
+(for_in_statement kind: _ left: (identifier) @definition.variable)
+
 (import_specifier name: (identifier) @definition.import)
 
 (type_parameter name: (type_identifier) @definition.type_parameter)

--- a/crates/core/src/languages/typescript/definition_queries.rs
+++ b/crates/core/src/languages/typescript/definition_queries.rs
@@ -6,7 +6,7 @@ use tree_sitter::Node;
 const QUERY: &str = include_str!("../../../queries/typescript/definitions.scm");
 
 /// What each capture in that file means, and whether it hoists.
-const ROLES: [(&str, DeclaredAs); 10] = [
+const ROLES: [(&str, DeclaredAs); 11] = [
     (
         "definition.class",
         DeclaredAs::hoisted(DefinitionType::ClassDefinition),
@@ -38,6 +38,10 @@ const ROLES: [(&str, DeclaredAs); 10] = [
     (
         "definition.property",
         DeclaredAs::plain(DefinitionType::PropertyDefinition),
+    ),
+    (
+        "definition.variable",
+        DeclaredAs::plain(DefinitionType::VariableDefinition),
     ),
     (
         "definition.import",

--- a/crates/test-generator/tests/snapshots/ts/test_generated_for_in_statement.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_for_in_statement.snap
@@ -29,10 +29,11 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition { position: { 1:12 to 1:15 }, name: "key", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+    ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:12 to 1:15 }, name: "key", kind: Identifier, context: None },
         Usage { position: { 1:19 to 1:22 }, name: "obj", kind: Identifier, context: None },
         Usage { position: { 1:26 to 1:33 }, name: "console", kind: Identifier, context: Some("call_expression") },
         Usage { position: { 1:34 to 1:37 }, name: "log", kind: FieldExpression, context: None },

--- a/crates/test-generator/tests/snapshots/ts/test_generated_try_statement.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_try_statement.snap
@@ -43,11 +43,11 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition { position: { 1:13 to 1:20 }, name: "result1", definition_type: VariableDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+        Definition { position: { 1:50 to 1:56 }, name: "error1", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
     usage: [
         Usage { position: { 1:23 to 1:39 }, name: "riskyOperation", kind: CallExpression, context: Some("call_expression") },
-        Usage { position: { 1:50 to 1:56 }, name: "error1", kind: Identifier, context: None },
         Usage { position: { 1:60 to 1:67 }, name: "console", kind: Identifier, context: Some("call_expression") },
         Usage { position: { 1:68 to 1:71 }, name: "log", kind: FieldExpression, context: None },
         Usage { position: { 1:72 to 1:78 }, name: "error1", kind: Identifier, context: Some("call_expression") },

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_for_in_statement.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_for_in_statement.snap
@@ -29,10 +29,11 @@ AST:
 IR:
 IntermediateRepresentation {
     file_path: "<memory>",
-    definitions: [],
+    definitions: [
+        Definition { position: { 1:12 to 1:15 }, name: "key", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+    ],
     dependencies: [],
     usage: [
-        Usage { position: { 1:12 to 1:15 }, name: "key", kind: Identifier, context: None },
         Usage { position: { 1:19 to 1:22 }, name: "obj", kind: Identifier, context: None },
         Usage { position: { 1:26 to 1:33 }, name: "console", kind: Identifier, context: Some("call_expression") },
         Usage { position: { 1:34 to 1:37 }, name: "log", kind: FieldExpression, context: None },

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_try_statement.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_try_statement.snap
@@ -43,11 +43,11 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition { position: { 1:13 to 1:20 }, name: "result1", definition_type: VariableDefinition, scope_id: Some(1), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
+        Definition { position: { 1:50 to 1:56 }, name: "error1", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
     usage: [
         Usage { position: { 1:23 to 1:39 }, name: "riskyOperation", kind: CallExpression, context: Some("call_expression") },
-        Usage { position: { 1:50 to 1:56 }, name: "error1", kind: Identifier, context: None },
         Usage { position: { 1:60 to 1:67 }, name: "console", kind: Identifier, context: Some("call_expression") },
         Usage { position: { 1:68 to 1:71 }, name: "log", kind: FieldExpression, context: None },
         Usage { position: { 1:72 to 1:78 }, name: "error1", kind: Identifier, context: Some("call_expression") },


### PR DESCRIPTION
close: #241

Two declaration forms produced no definition, so their names were read as references — one inventing an edge, the other losing one.

```typescript
const shared = 1;                  // L1
try { return shared; }             // L5 -> L1, correct
catch (shared) { return 0; }       // L6 -> L1, INVENTED
```

```typescript
for (const item of items) {        // L3, no definition
    total += item;                 // L4, no edge to item
}
```

## The `for` that does not declare

`for (existing of values)` with no `const`/`let`/`var` assigns to a binding that already exists, so it reads rather than declares. The two forms are identical in `left:` — the only difference is the presence of the `kind:` field, which the query requires:

```scheme
(for_in_statement kind: _ left: (identifier) @binding)
```

`left:` may also be a `member_expression` (`for (obj.k of xs)`), an assignment target, correctly unmatched.

## Why the earlier sweep missed these

The `node-types.json` sweep behind #233 and #234 looked for nodes with a **`name:`** field. These use `parameter:` and `left:`. Worth widening next time it is run.

Rust was checked at the same time: `for item in xs` already produces a definition and resolves correctly. This is TypeScript only.

## Verification

- accuracy `510 / 510`, precision 1.000, recall 1.000; `loop_and_catch_bindings.ts` adds 12 expectations
- every name in the fixture shadows one at the top level, so reading a declaration as a reference shows up as an edge to the wrong line. Both `for` forms are covered, since the keyword-less one must keep referencing the outer binding
- 4 snapshots change: `key` and `error1` each move from a usage they never were to the definition they are
- `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)