### PR TITLE
fix: link every implemented member to its declaration, not only methods

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -9,9 +9,9 @@
       "duplicates": 1
     },
     "rust/associated_types.rs": {
-      "expected": 10,
-      "detected": 10,
-      "correct": 10,
+      "expected": 11,
+      "detected": 11,
+      "correct": 11,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -193,9 +193,9 @@
       "duplicates": 0
     },
     "rust/traits.rs": {
-      "expected": 12,
-      "detected": 12,
-      "correct": 12,
+      "expected": 18,
+      "detected": 18,
+      "correct": 18,
       "missing": 0,
       "spurious": 0,
       "duplicates": 1
@@ -353,9 +353,9 @@
       "duplicates": 0
     },
     "typescript/interfaces.ts": {
-      "expected": 10,
-      "detected": 10,
-      "correct": 10,
+      "expected": 14,
+      "detected": 14,
+      "correct": 14,
       "missing": 0,
       "spurious": 0,
       "duplicates": 1
@@ -410,9 +410,9 @@
     }
   },
   "total": {
-    "expected": 515,
-    "detected": 515,
-    "correct": 515,
+    "expected": 526,
+    "detected": 526,
+    "correct": 526,
     "missing": 0,
     "spurious": 0,
     "duplicates": 27

--- a/crates/accuracy/fixtures/rust/associated_types.rs
+++ b/crates/accuracy/fixtures/rust/associated_types.rs
@@ -2,24 +2,27 @@
 //
 // `Self::Item` inside the impl names the impl's own alias, which is nearer than the trait's
 // declaration. `Self` itself is the type inside an impl and the trait inside a trait.
+//
+// The impl's alias also references the trait's declaration, the same way an implemented method
+// references the signature it satisfies.
 
 trait Container {
     type Item;
 
-    fn first(&self) -> Self::Item; //~ depends: Container@6, Item@7
+    fn first(&self) -> Self::Item; //~ depends: Container@9, Item@10
 }
 
 struct Numbers;
 
-impl Container for Numbers { //~ depends: Container@6, Numbers@12
-    type Item = i32;
+impl Container for Numbers { //~ depends: Container@9, Numbers@15
+    type Item = i32; //~ depends: Item@10
 
-    fn first(&self) -> Self::Item { //~ depends: first@9, Numbers@12, Item@15
+    fn first(&self) -> Self::Item { //~ depends: first@12, Numbers@15, Item@18
         1
     }
 }
 
 fn main() {
-    let n = Numbers; //~ depends: Numbers@12
-    let _ = n.first(); //~ depends: first@17, n@23
+    let n = Numbers; //~ depends: Numbers@15
+    let _ = n.first(); //~ depends: first@20, n@26
 }

--- a/crates/accuracy/fixtures/rust/traits.rs
+++ b/crates/accuracy/fixtures/rust/traits.rs
@@ -24,3 +24,21 @@ fn main() {
     let a = s.scaled(2); //~ depends: scaled@17, s@23
     let _ = a; //~ depends: a@24
 }
+
+// A trait declares consts alongside methods, and an implementation is coupled to each of them the
+// same way.
+trait Bounded {
+    const LIMIT: i32;
+
+    fn headroom(&self) -> i32;
+}
+
+struct Gauge;
+
+impl Bounded for Gauge { //~ depends: Bounded@30, Gauge@36
+    const LIMIT: i32 = 10; //~ depends: LIMIT@31
+
+    fn headroom(&self) -> i32 { //~ depends: headroom@33
+        Self::LIMIT //~ depends: Gauge@36, LIMIT@39
+    }
+}

--- a/crates/accuracy/fixtures/typescript/interfaces.ts
+++ b/crates/accuracy/fixtures/typescript/interfaces.ts
@@ -20,3 +20,19 @@ class Square implements Shape { //~ depends: Shape@3
 
 const s = new Square(2); //~ depends: Square@9
 const a = s.area(); //~ depends: area@16, s@21
+
+// An interface declares properties alongside methods, and a class field satisfying one is coupled
+// to it the same way a method is.
+interface Named {
+    label: string;
+
+    describe(): string;
+}
+
+class Tag implements Named { //~ depends: Named@26
+    label = "tag"; //~ depends: label@27
+
+    describe(): string { //~ depends: describe@29
+        return this.label; //~ depends: label@33
+    }
+}

--- a/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
@@ -3,11 +3,16 @@ use crate::models::Dependency;
 use tree_sitter::Node;
 
 const QUERIES: Queries = Queries {
+    // A trait declares consts and types alongside methods, and an implementation is coupled to each
+    // of them the same way, so all three are captured under one name.
     implementations: r#"
         (impl_item
           trait: [(type_identifier) (generic_type)] @type
-          body: (declaration_list
-            (function_item name: (identifier) @method)))
+          body: (declaration_list [
+            (function_item name: (identifier) @method)
+            (const_item name: (identifier) @method)
+            (type_item name: (type_identifier) @method)
+          ]))
     "#,
     // An implementation can satisfy a required signature or override a method the trait already
     // provides a body for, so both count as declarations.
@@ -17,6 +22,8 @@ const QUERIES: Queries = Queries {
           body: (declaration_list [
             (function_signature_item name: (identifier) @method)
             (function_item name: (identifier) @method)
+            (const_item name: (identifier) @method)
+            (associated_type name: (type_identifier) @method)
           ]))
     "#,
     // `trait Extended: Base` inherits Base's declarations, so an implementation of Extended can be

--- a/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
@@ -11,26 +11,36 @@ const QUERIES: Queries = Queries {
             (implements_clause [(type_identifier) (generic_type)] @type)
             (extends_clause value: (identifier) @type)
           ])
-          body: (class_body
-            (method_definition name: (property_identifier) @method)))
+          body: (class_body [
+            (method_definition name: (property_identifier) @method)
+            (public_field_definition name: (property_identifier) @method)
+          ]))
     "#,
     // A base class declares by providing a body, so its methods count as declarations alongside
     // the signatures an interface declares. An abstract class declares both ways at once.
+    //
+    // An interface declares properties as well as methods, and a class field satisfying one is
+    // coupled to it the same way a method is, so both are captured under one name.
     declarations: r#"
         [
           (interface_declaration
             name: (type_identifier) @type
-            body: (interface_body
-              (method_signature name: (property_identifier) @method)))
+            body: (interface_body [
+              (method_signature name: (property_identifier) @method)
+              (property_signature name: (property_identifier) @method)
+            ]))
           (class_declaration
             name: (type_identifier) @type
-            body: (class_body
-              (method_definition name: (property_identifier) @method)))
+            body: (class_body [
+              (method_definition name: (property_identifier) @method)
+              (public_field_definition name: (property_identifier) @method)
+            ]))
           (abstract_class_declaration
             name: (type_identifier) @type
             body: (class_body [
               (abstract_method_signature name: (property_identifier) @method)
               (method_definition name: (property_identifier) @method)
+              (public_field_definition name: (property_identifier) @method)
             ]))
         ]
     "#,


### PR DESCRIPTION
close: #246

#175 and #188 established that an implementation is coupled to the contract it satisfies. Only **methods** got the edge.

```rust
impl Spec for Impl {
    const MAX: i32 = 1;    // no edge to the trait's `const MAX: i32;`
    type Out = i32;        // no edge to the trait's `type Out;`
    fn run(&self) { .. }   // edge present
}
```

```typescript
class Impl implements Spec {
    size = 1;              // no edge to the interface's `size: number;`
    run(): number { .. }   // edge present
}
```

## What was added

| Language | To `implementations` | To `declarations` |
| --- | --- | --- |
| Rust | `const_item`, `type_item` | `const_item`, `associated_type` |
| TypeScript | `public_field_definition` | `property_signature`, `public_field_definition` |

The shared `trait_implementation.rs` pairs on (declaring type, member name) and does not care what kind of member it is, so capturing the new forms under the same `@method` name is the whole change — queries only, no Rust.

Inheritance works unchanged: a supertype lookup finds a const declared on a base trait the same way it finds a method.

## An existing fixture reported the new edge as spurious

`rust/associated_types.rs` already declared `type Item;` and implemented it, and read 1.000 — it simply never annotated the edge to the trait's declaration, because that edge did not exist. Adding the query surfaced it as `spurious: L15 -> L7 "Item"`, which is the harness reporting a **genuine new edge** rather than a defect. It is annotated now and the fixture's header says so.

## Verification

- accuracy `526 / 526`, precision 1.000, recall 1.000 (516 → 526 expectations)
- `rust/traits.rs` and `typescript/interfaces.ts` each grow by an implemented const / property
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

## Also probed, already correct

Rust associated consts read through `Self::MAX` and `Type::MAX`, `async fn` / `.await`, loop labels, and closures capturing their environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)