### PR TITLE
fix(typescript): link an abstract class's members to what they implement

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -249,9 +249,9 @@
       "duplicates": 0
     },
     "typescript/abstract_classes.ts": {
-      "expected": 7,
-      "detected": 7,
-      "correct": 7,
+      "expected": 15,
+      "detected": 15,
+      "correct": 15,
       "missing": 0,
       "spurious": 0,
       "duplicates": 1
@@ -410,9 +410,9 @@
     }
   },
   "total": {
-    "expected": 526,
-    "detected": 526,
-    "correct": 526,
+    "expected": 534,
+    "detected": 534,
+    "correct": 534,
     "missing": 0,
     "spurious": 0,
     "duplicates": 27

--- a/crates/accuracy/fixtures/typescript/abstract_classes.ts
+++ b/crates/accuracy/fixtures/typescript/abstract_classes.ts
@@ -18,3 +18,25 @@ class Square extends Shape { //~ depends: Shape@3
 
 const s = new Square(); //~ depends: Square@11
 const text = s.describe(); //~ depends: describe@6, s@19
+
+// An abstract class satisfies a contract while declaring one of its own, so its members reference
+// what the interface declared as well as being referenced by the class below.
+interface Tagged {
+    tag: string;
+
+    render(): string;
+}
+
+abstract class Partial implements Tagged { //~ depends: Tagged@24
+    abstract tag: string; //~ depends: tag@25
+
+    render(): string { //~ depends: render@27
+        return this.tag; //~ depends: tag@31
+    }
+}
+
+class Concrete extends Partial { //~ depends: Partial@30
+    tag = "concrete"; //~ depends: tag@31
+}
+
+const rendered = new Concrete().render(); //~ depends: Concrete@38, render@33

--- a/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
@@ -5,16 +5,30 @@ use tree_sitter::Node;
 const QUERIES: Queries = Queries {
     // A class method can satisfy an interface it implements or override one from the class it
     // extends, so both heritage clauses name a type whose declarations it may be satisfying.
+    // An abstract class implements and extends the same way a concrete one does, so it appears here
+    // as well as among the declarations — it satisfies a contract while declaring one of its own.
     implementations: r#"
-        (class_declaration
-          (class_heritage [
-            (implements_clause [(type_identifier) (generic_type)] @type)
-            (extends_clause value: (identifier) @type)
-          ])
-          body: (class_body [
-            (method_definition name: (property_identifier) @method)
-            (public_field_definition name: (property_identifier) @method)
-          ]))
+        [
+          (class_declaration
+            (class_heritage [
+              (implements_clause [(type_identifier) (generic_type)] @type)
+              (extends_clause value: (identifier) @type)
+            ])
+            body: (class_body [
+              (method_definition name: (property_identifier) @method)
+              (public_field_definition name: (property_identifier) @method)
+            ]))
+          (abstract_class_declaration
+            (class_heritage [
+              (implements_clause [(type_identifier) (generic_type)] @type)
+              (extends_clause value: (identifier) @type)
+            ])
+            body: (class_body [
+              (method_definition name: (property_identifier) @method)
+              (public_field_definition name: (property_identifier) @method)
+              (abstract_method_signature name: (property_identifier) @method)
+            ]))
+        ]
     "#,
     // A base class declares by providing a body, so its methods count as declarations alongside
     // the signatures an interface declares. An abstract class declares both ways at once.


### PR DESCRIPTION
close: #248

```typescript
interface Base {
    tag: string;              // L2
    describe(): string;       // L3
}

abstract class Partial implements Base {
    abstract tag: string;     // L7  ->  no edge to L2
    describe(): string { .. } // L9  ->  no edge to L3
}
```

The `implementations` query matched only `class_declaration`. #202 added `abstract_class_declaration` to `definitions.scm`, to `declarations` and to `supertypes` — so an abstract class was recognised as **declaring** a contract and as a supertype, but never as **satisfying** one.

It does both at once: `class Concrete extends Partial` already linked to `Partial`'s members, and `Partial`'s own now link on to `Base`'s. `abstract_method_signature` is included among the member kinds, since an abstract signature satisfies a declaration as much as a concrete body does.

Query change only — no Rust.

## Verification

- accuracy `534 / 534`, precision 1.000, recall 1.000 (526 → 534)
- `typescript/abstract_classes.ts` grows from 7 to 15 expectations. Its abstract class only **extended** before, never appeared on the implementing side of an `implements` clause, so that whole direction was unmeasured. The chain now runs interface → abstract class → concrete class
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

## Also probed, already correct

Rust `impl<T> Show for Wrap<T>` (generic impls link their const and method), operator traits through a `use`, `pub use` re-exports, `crate::` and `self::` paths, `impl Trait` returns; TypeScript static blocks, parameter properties, method overload signatures, and `super(...)` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript dependency analysis for abstract classes, including implemented interfaces, inherited classes, and abstract members.
  * Increased accuracy for detecting relationships in abstract class declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->