### PR TITLE
feat(accuracy): say when annotations were written against a different numbering

### DIFF
--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -106,6 +106,26 @@ The same growth also corrected assumptions recorded here earlier: that the analy
 under-reports (#187 disproved it), and that it makes no false positives (#197 invents edges from
 nothing more than a shared field name).
 
+### Editing a fixture's header moves every annotation below it
+
+Adding a sentence to the comment at the top of a fixture shifts every line under it, and every
+`@line` written before that edit now points one short. The harness reports a wall of missing and
+spurious edges, which reads like a broken analyzer.
+
+It says so instead:
+
+```
+  every missing edge is a spurious one 1 line later: the annotations were written against a
+  different numbering, so check whether a line was added or removed above them
+```
+
+The signature is that each missing edge has a spurious twin naming the same symbol from the same
+source line, all at one offset. Where the offsets disagree, or only some edges have a twin, nothing
+is claimed — two unrelated defects are not a shift, and explaining them away would hide them.
+
+When it fires, strip every annotation and re-derive them against the new numbering rather than
+adjusting them one at a time.
+
 Writing expectations is not free of error either. Several apparent defects turned out to be wrong
 annotations — a JSX attribute does reference the prop it names, a type parameter reference is real,
 `super::X` does not depend on the module's declaration. When a fixture disagrees with the analyzer,

--- a/crates/accuracy/src/lib.rs
+++ b/crates/accuracy/src/lib.rs
@@ -12,6 +12,7 @@ pub mod edge;
 pub mod expectation;
 pub mod fixtures;
 pub mod report;
+pub mod shift;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/accuracy/src/report.rs
+++ b/crates/accuracy/src/report.rs
@@ -91,8 +91,11 @@ fn row(name: &str, counts: &Counts) -> Vec<String> {
 fn fixture_details(fixture: &FixtureReport) -> String {
     let missing = edge_lines("missing", &fixture.missing);
     let spurious = edge_lines("spurious", &fixture.spurious);
+    let shift = crate::shift::detect(&fixture.missing, &fixture.spurious)
+        .map(crate::shift::explain)
+        .unwrap_or_default();
 
-    format!("{}\n{missing}{spurious}", fixture.name)
+    format!("{}\n{missing}{spurious}{shift}", fixture.name)
 }
 
 fn edge_lines(label: &str, edges: &[crate::edge::Edge]) -> String {

--- a/crates/accuracy/src/shift.rs
+++ b/crates/accuracy/src/shift.rs
@@ -1,0 +1,61 @@
+//! Recognising a fixture whose annotations were written against a different numbering.
+//!
+//! Inserting a line — a sentence in the header comment, usually — moves every line below it, and
+//! every annotation written before that edit then points one or more lines short. The harness sees
+//! it as a fixture full of missing and spurious edges, which reads like a broken analyzer rather
+//! than a stale annotation.
+//!
+//! The signature is that each missing edge has a spurious twin naming the same symbol, at the same
+//! offset. Saying so turns a wall of edges into one sentence.
+
+use crate::edge::Edge;
+
+/// The offset by which every missing edge is a shifted spurious one, when that is what happened.
+///
+/// Requires the same count on both sides and one consistent non-zero offset, so a fixture that
+/// genuinely lost and gained edges is not explained away as a shift.
+pub fn detect(missing: &[Edge], spurious: &[Edge]) -> Option<isize> {
+    if missing.is_empty() || missing.len() != spurious.len() {
+        return None;
+    }
+
+    let offset = offset_between(&missing[0], spurious)?;
+
+    missing
+        .iter()
+        .all(|edge| offset_between(edge, spurious) == Some(offset))
+        .then_some(offset)
+}
+
+/// The single offset at which this edge appears among the spurious ones.
+///
+/// A symbol appearing at two different offsets is ambiguous, so no offset is reported rather than
+/// an arbitrary one.
+fn offset_between(missing: &Edge, spurious: &[Edge]) -> Option<isize> {
+    let mut offsets = spurious
+        .iter()
+        .filter(|candidate| candidate.symbol == missing.symbol)
+        .filter(|candidate| candidate.source_line == missing.source_line)
+        .map(|candidate| candidate.target_line as isize - missing.target_line as isize)
+        .filter(|offset| *offset != 0)
+        .collect::<Vec<_>>();
+
+    offsets.dedup();
+    match offsets.as_slice() {
+        [offset] => Some(*offset),
+        _ => None,
+    }
+}
+
+/// What to tell the reader when a shift is what happened.
+pub fn explain(offset: isize) -> String {
+    let direction = if offset > 0 { "later" } else { "earlier" };
+    let lines = offset.abs();
+    let plural = if lines == 1 { "line" } else { "lines" };
+
+    format!(
+        "  every missing edge is a spurious one {lines} {plural} {direction}: the annotations were \
+         written against a different numbering, so check whether a line was added or removed above \
+         them\n"
+    )
+}

--- a/crates/accuracy/tests/unit/mod.rs
+++ b/crates/accuracy/tests/unit/mod.rs
@@ -1,2 +1,3 @@
 mod comparison_tests;
 mod expectation_tests;
+mod shift_tests;

--- a/crates/accuracy/tests/unit/shift_tests.rs
+++ b/crates/accuracy/tests/unit/shift_tests.rs
@@ -1,0 +1,60 @@
+use lintric_accuracy::edge::Edge;
+use lintric_accuracy::shift::detect;
+
+#[test]
+fn recognises_every_target_moved_by_one_line() {
+    // What inserting a sentence into the header comment does to a fixture.
+    let missing = edges([(6, 4, "a"), (7, 5, "b")]);
+    let spurious = edges([(6, 5, "a"), (7, 6, "b")]);
+
+    assert_eq!(detect(&missing, &spurious), Some(1));
+}
+
+#[test]
+fn recognises_a_shift_in_the_other_direction() {
+    let missing = edges([(6, 5, "a")]);
+    let spurious = edges([(6, 3, "a")]);
+
+    assert_eq!(detect(&missing, &spurious), Some(-2));
+}
+
+#[test]
+fn stays_quiet_when_the_offsets_disagree() {
+    // Two unrelated defects are not a shift, and claiming otherwise would hide them.
+    let missing = edges([(6, 4, "a"), (7, 5, "b")]);
+    let spurious = edges([(6, 5, "a"), (7, 9, "b")]);
+
+    assert_eq!(detect(&missing, &spurious), None);
+}
+
+#[test]
+fn stays_quiet_when_only_some_edges_have_a_twin() {
+    let missing = edges([(6, 4, "a"), (7, 5, "b")]);
+    let spurious = edges([(6, 5, "a")]);
+
+    assert_eq!(detect(&missing, &spurious), None);
+}
+
+#[test]
+fn stays_quiet_when_a_symbol_appears_at_two_offsets() {
+    // Ambiguous, so no offset is better than an arbitrary one.
+    let missing = edges([(6, 4, "a"), (6, 8, "a")]);
+    let spurious = edges([(6, 5, "a"), (6, 10, "a")]);
+
+    assert_eq!(detect(&missing, &spurious), None);
+}
+
+#[test]
+fn stays_quiet_when_nothing_is_wrong() {
+    assert_eq!(detect(&[], &[]), None);
+}
+
+fn edges<const N: usize>(rows: [(usize, usize, &str); N]) -> Vec<Edge> {
+    rows.into_iter()
+        .map(|(source_line, target_line, symbol)| Edge {
+            source_line,
+            target_line,
+            symbol: symbol.to_string(),
+        })
+        .collect()
+}


### PR DESCRIPTION
Adding a sentence to a fixture's header comment shifts every line below it, so every `@line` written before that edit points one short. The harness then reports a wall of missing and spurious edges — which reads like a broken analyzer rather than a stale annotation.

That has now cost several rounds of re-deriving expectations by hand across this work, so the harness recognises it:

```
rust/variables.rs
  missing: L6 -> L4 "a"
  missing: L7 -> L5 "b"
  ...
  spurious: L6 -> L5 "a"
  spurious: L7 -> L6 "b"
  ...
  every missing edge is a spurious one 1 line later: the annotations were written against a
  different numbering, so check whether a line was added or removed above them
```

## When it stays quiet

The signature is that each missing edge has a spurious twin naming the same symbol **from the same source line**, all at one consistent non-zero offset. Nothing is claimed when:

- the offsets disagree — two unrelated defects are not a shift, and explaining them away would hide them
- only some edges have a twin
- a symbol appears at two different offsets, which is ambiguous
- nothing is wrong

All six cases are covered by unit tests. Verified end to end by inserting a line into `rust/variables.rs` and reading the output, then restoring it.

The accuracy README records the diagnostic and the advice that goes with it: when it fires, strip every annotation and re-derive against the new numbering rather than adjusting them one at a time.

No change to what is measured — `534 / 534`, precision 1.000, recall 1.000, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)