### PR TITLE
fix(typescript): stop collecting a pattern's default value as a binding

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -305,9 +305,9 @@
       "duplicates": 0
     },
     "typescript/destructuring.ts": {
-      "expected": 11,
-      "detected": 11,
-      "correct": 11,
+      "expected": 22,
+      "detected": 22,
+      "correct": 22,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -410,9 +410,9 @@
     }
   },
   "total": {
-    "expected": 534,
-    "detected": 534,
-    "correct": 534,
+    "expected": 545,
+    "detected": 545,
+    "correct": 545,
     "missing": 0,
     "spurious": 0,
     "duplicates": 27

--- a/crates/accuracy/fixtures/typescript/destructuring.ts
+++ b/crates/accuracy/fixtures/typescript/destructuring.ts
@@ -19,3 +19,17 @@ const total = first + rest.length; //~ depends: first@17, rest@17
 
 const { x: renamed } = origin; //~ depends: origin@11
 const _ = shift(origin) + total + renamed; //~ depends: shift@13, origin@11, total@18, renamed@20
+
+// A default value and a computed key are read rather than declared, so each references what it
+// names instead of shadowing it.
+const fallback = 9;
+const key = "x";
+
+const { x = fallback } = origin; //~ depends: fallback@25, origin@11
+const { [key]: byKey } = origin; //~ depends: key@26, origin@11
+
+function withDefault({ y = fallback }: Point): number { //~ depends: Point@6, fallback@25
+    return y; //~ depends: y@31
+}
+
+const used = x + byKey + withDefault(origin); //~ depends: x@28, byKey@29, withDefault@31, origin@11

--- a/crates/core/src/languages/typescript/typescript_node_extractors.rs
+++ b/crates/core/src/languages/typescript/typescript_node_extractors.rs
@@ -216,21 +216,42 @@ impl TypeScriptDefinitionExtractor {
         has_modifier
     }
 
+    /// The names a destructuring pattern binds.
+    ///
+    /// Not every identifier under a pattern is one: a default value and a computed key are read
+    /// rather than declared, and collecting them as bindings made each shadow the declaration it
+    /// was naming.
     #[allow(clippy::only_used_in_recursion)]
     fn find_identifier_nodes_in_node<'a>(&self, node: Node<'a>) -> Vec<Node<'a>> {
-        let mut identifiers = vec![];
-        if node.kind() == "identifier" {
-            identifiers.push(node);
-        } else if node.kind() == "shorthand_property_identifier_pattern" {
-            // shorthand_property_identifier_pattern is itself an identifier in destructuring
-            identifiers.push(node);
-        } else {
-            let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                identifiers.extend(self.find_identifier_nodes_in_node(child));
+        // A shorthand pattern name is itself the identifier, since `{ x }` has no separate node.
+        if matches!(
+            node.kind(),
+            "identifier" | "shorthand_property_identifier_pattern"
+        ) {
+            return vec![node];
+        }
+
+        Self::binding_children(node)
+            .iter()
+            .flat_map(|child| self.find_identifier_nodes_in_node(*child))
+            .collect()
+    }
+
+    /// The children of a pattern node that can hold a bound name.
+    ///
+    /// `x = fallback` binds only its left side, and `[k]: v` binds only the value — the key names
+    /// something declared elsewhere.
+    fn binding_children<'a>(node: Node<'a>) -> Vec<Node<'a>> {
+        match node.kind() {
+            "assignment_pattern" | "object_assignment_pattern" => {
+                node.child_by_field_name("left").into_iter().collect()
+            }
+            "computed_property_name" => vec![],
+            _ => {
+                let mut cursor = node.walk();
+                node.children(&mut cursor).collect()
             }
         }
-        identifiers
     }
 
     #[allow(dead_code)]

--- a/crates/test-generator/tests/snapshots/ts/test_generated_object_assignment_pattern.snap
+++ b/crates/test-generator/tests/snapshots/ts/test_generated_object_assignment_pattern.snap
@@ -25,7 +25,6 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition { position: { 1:9 to 1:14 }, name: "prop3", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
-        Definition { position: { 1:17 to 1:27 }, name: "defaultVal", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
     usage: [

--- a/crates/test-generator/tests/snapshots/tsx/test_generated_object_assignment_pattern.snap
+++ b/crates/test-generator/tests/snapshots/tsx/test_generated_object_assignment_pattern.snap
@@ -25,7 +25,6 @@ IntermediateRepresentation {
     file_path: "<memory>",
     definitions: [
         Definition { position: { 1:9 to 1:14 }, name: "prop5", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
-        Definition { position: { 1:17 to 1:27 }, name: "defaultVal", definition_type: VariableDefinition, scope_id: Some(0), accessibility: Some(ScopeLocal), is_hoisted: Some(false) },
     ],
     dependencies: [],
     usage: [


### PR DESCRIPTION
close: #252

`const { x = fallback } = src` **reads** `fallback`. It was collected as a binding, so the reference shadowed the declaration it was naming, resolved to itself on its own line, and the edge was dropped:

```typescript
const fb = "x";                       // L1
const { host = fb } = { host: "y" };  // L2   fb registered as a binding here
const [a = fb] = ["z"];               // L3   and here
function f({ port = fb }) { .. }      // L4   and here
```
```
deps: (none)     ->    2 -> 1 fb, 3 -> 1 fb, 4 -> 1 fb
```

A computed key was collected the same way:

```typescript
const { [k]: picked } = src;   // no edge to k's declaration
```

## Cause

`find_identifier_nodes_in_node` recursed into **every** child of a pattern, so it descended into `assignment_pattern`'s and `object_assignment_pattern`'s `right:` and into `computed_property_name`. Neither holds a bound name — `x = fallback` binds only its left side, and `[k]: v` binds only the value.

The recursion is now restricted to the children that can hold one.

## Verification

- accuracy `545 / 545`, precision 1.000, recall 1.000 (534 → 545)
- `typescript/destructuring.ts` grows from 11 to 22 expectations. It covered object, array, rest and renaming patterns but neither of these forms, so the whole read-rather-than-bind half of a pattern was unmeasured
- 2 snapshots change: `defaultVal` stops being recorded as a definition it never was
- `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

Rust has no pattern defaults; `let P { x } = p` was checked and is correct.

## Filed, not fixed

#251 — a `let` shadowing across a block boundary loses the edge to what it reads. The obvious fix was tried and reverted: it trades one missing edge for two invented ones, and position alone cannot tell `let x = x + 1` (the binding is not live in its own initializer) from `|x| x + 1` and `impl<const N> Buffer<N>` (both visible on their own line). The issue records the attempt and what a real fix needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)