### PR TITLE
fix(rust): resolve a method call by the receiver's type

### DIFF
--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -217,6 +217,18 @@ The cost is symmetrical to the object-shape decision and worth stating: a genuin
 unannotated receiver loses its edge. `typescript/member_access.ts` pins both halves, including the
 non-edge.
 
+Rust works the same way, with the type read from a parameter, a `let` annotation, a `let` whose
+initializer names a type, or `self` inside an impl. `rust/method_receivers.rs` pins it.
+
+Two consequences are worth stating outright, because they look like lost edges and are not:
+
+- `fn measure(shape: impl Shape)` and `fn measure(shape: &dyn Shape)` state **the trait**, so
+  `shape.area()` reaches the trait's declaration rather than any implementor's. Both fixtures
+  recorded an implementor before the receiver's type was consulted, and both were wrong.
+- a receiver whose type comes from a return value — `let cloned = item.clone(); cloned.display()` —
+  is unknown, so a method name declared by more than one type resolves to nothing. Guessing pointed
+  at an arbitrary implementor.
+
 ## Still unsettled
 
 **Functional update.** Whether `Point { ..other }` should imply a dependency on every field

--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -136,6 +136,14 @@
       "spurious": 0,
       "duplicates": 0
     },
+    "rust/method_receivers.rs": {
+      "expected": 17,
+      "detected": 17,
+      "correct": 17,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "rust/nested_modules.rs": {
       "expected": 11,
       "detected": 11,
@@ -410,9 +418,9 @@
     }
   },
   "total": {
-    "expected": 545,
-    "detected": 545,
-    "correct": 545,
+    "expected": 562,
+    "detected": 562,
+    "correct": 562,
     "missing": 0,
     "spurious": 0,
     "duplicates": 27

--- a/crates/accuracy/fixtures/rust/impl_trait.rs
+++ b/crates/accuracy/fixtures/rust/impl_trait.rs
@@ -1,4 +1,8 @@
 // `impl Trait` in argument and return position.
+//
+// `shape: impl Shape` states the trait and nothing else, so `shape.area()` reaches the trait's
+// declaration rather than any implementor's — pointing at Square's would claim a relationship with a
+// type this line never names, and would be a guess as soon as a second implementor existed.
 
 trait Shape {
     fn area(&self) -> i32;
@@ -6,20 +10,20 @@ trait Shape {
 
 struct Square;
 
-impl Shape for Square { //~ depends: Shape@3, Square@7
-    fn area(&self) -> i32 { //~ depends: area@4
+impl Shape for Square { //~ depends: Shape@7, Square@11
+    fn area(&self) -> i32 { //~ depends: area@8
         1
     }
 }
 
-fn make() -> impl Shape { //~ depends: Shape@3
-    Square //~ depends: Square@7
+fn make() -> impl Shape { //~ depends: Shape@7
+    Square //~ depends: Square@11
 }
 
-fn measure(shape: impl Shape) -> i32 { //~ depends: Shape@3
-    shape.area() //~ depends: shape@19, area@10
+fn measure(shape: impl Shape) -> i32 { //~ depends: Shape@7
+    shape.area() //~ depends: shape@23, area@8
 }
 
 fn main() {
-    let _ = measure(make()); //~ depends: measure@19, make@15
+    let _ = measure(make()); //~ depends: measure@23, make@19
 }

--- a/crates/accuracy/fixtures/rust/method_receivers.rs
+++ b/crates/accuracy/fixtures/rust/method_receivers.rs
@@ -1,0 +1,43 @@
+// Method calls told apart by the receiver's type.
+//
+// Two types declaring a method of the same name are distinguished by what the receiver is: a
+// parameter or a `let` whose type the file states, or `self` inside an impl. Where the file does not
+// state it, the call is left unresolved rather than pointed at both declarations. See #254.
+
+struct First;
+
+struct Second;
+
+impl First { //~ depends: First@7
+    fn value(&self) -> i32 {
+        1
+    }
+
+    fn doubled(&self) -> i32 {
+        self.value() * 2 //~ depends: value@12
+    }
+}
+
+impl Second { //~ depends: Second@9
+    fn value(&self) -> i32 {
+        2
+    }
+}
+
+fn from_parameter(f: First) -> i32 { //~ depends: First@7
+    f.value() //~ depends: f@27, value@12
+}
+
+fn from_annotated_binding(s: Second) -> i32 { //~ depends: Second@9
+    let bound: Second = s; //~ depends: Second@9, s@31
+    bound.value() //~ depends: bound@32, value@22
+}
+
+fn from_initializer() -> i32 {
+    let made = First; //~ depends: First@7
+    made.value() //~ depends: made@37, value@12
+}
+
+fn through_a_borrow(s: &Second) -> i32 { //~ depends: Second@9
+    (*s).value() //~ depends: s@41, value@22
+}

--- a/crates/accuracy/fixtures/rust/trait_objects.rs
+++ b/crates/accuracy/fixtures/rust/trait_objects.rs
@@ -1,4 +1,8 @@
 // Trait objects behind references and boxes.
+//
+// `&dyn Shape` states the trait and nothing else, so `shape.area()` reaches the trait's declaration
+// rather than any implementor's — pointing at Square's would claim a relationship with a type this
+// line never names, and would be a guess as soon as a second implementor existed.
 
 trait Shape {
     fn area(&self) -> i32;
@@ -6,22 +10,22 @@ trait Shape {
 
 struct Square;
 
-impl Shape for Square { //~ depends: Shape@3, Square@7
-    fn area(&self) -> i32 { //~ depends: area@4
+impl Shape for Square { //~ depends: Shape@7, Square@11
+    fn area(&self) -> i32 { //~ depends: area@8
         1
     }
 }
 
-fn measure(shape: &dyn Shape) -> i32 { //~ depends: Shape@3
-    shape.area() //~ depends: shape@15, area@10
+fn measure(shape: &dyn Shape) -> i32 { //~ depends: Shape@7
+    shape.area() //~ depends: shape@19, area@8
 }
 
-fn boxed() -> Box<dyn Shape> { //~ depends: Shape@3
-    Box::new(Square) //~ depends: Square@7
+fn boxed() -> Box<dyn Shape> { //~ depends: Shape@7
+    Box::new(Square) //~ depends: Square@11
 }
 
 fn main() {
-    let s = Square; //~ depends: Square@7
-    let _ = measure(&s); //~ depends: measure@15, s@24
-    let _ = boxed(); //~ depends: boxed@19
+    let s = Square; //~ depends: Square@11
+    let _ = measure(&s); //~ depends: measure@19, s@28
+    let _ = boxed(); //~ depends: boxed@23
 }

--- a/crates/core/queries/rust/enclosing_impls.scm
+++ b/crates/core/queries/rust/enclosing_impls.scm
@@ -1,0 +1,10 @@
+; Where each impl or trait body begins and ends, so that a `self.method()` call can be attributed to
+; the type it sits inside.
+
+(impl_item
+  type: [(type_identifier) (generic_type)] @owner
+  body: (declaration_list) @body)
+
+(trait_item
+  name: (type_identifier) @owner
+  body: (declaration_list) @body)

--- a/crates/core/queries/rust/method_calls.scm
+++ b/crates/core/queries/rust/method_calls.scm
@@ -1,0 +1,11 @@
+; What each `receiver.method()` call reads from, keyed by the position of the whole field expression,
+; since that is the position the usage carries — Rust records a method call at the start of the
+; receiver rather than at the method's own name.
+;
+; The receiver is captured whole rather than as a name: it may be `self`, a borrow, or a
+; parenthesised expression, and what it is gets decided in Rust.
+
+(call_expression
+  function: (field_expression
+    value: (_) @receiver
+    field: (field_identifier)) @accessed)

--- a/crates/core/queries/rust/method_owners.scm
+++ b/crates/core/queries/rust/method_owners.scm
@@ -1,0 +1,19 @@
+; Which type declares a method, so that `receiver.method()` can be pointed at the one the receiver's
+; type declares rather than at every method sharing that name.
+;
+; The method's name node is captured because its position is what a Definition carries. A trait
+; declares as well: a blanket impl's `self.name()` names the trait's method, not any implementor's.
+
+(impl_item
+  type: [(type_identifier) (generic_type)] @owner
+  body: (declaration_list [
+    (function_item name: (identifier) @member)
+    (function_signature_item name: (identifier) @member)
+  ]))
+
+(trait_item
+  name: (type_identifier) @owner
+  body: (declaration_list [
+    (function_item name: (identifier) @member)
+    (function_signature_item name: (identifier) @member)
+  ]))

--- a/crates/core/queries/rust/receiver_types.scm
+++ b/crates/core/queries/rust/receiver_types.scm
@@ -1,0 +1,24 @@
+; Bindings whose type is stated where they are declared, which is the only way a single file can know
+; what `receiver.method()` reaches. A binding with no annotation is left unknown rather than guessed
+; at.
+;
+; The whole type is captured rather than a name, because a reference or a generic wraps it.
+
+(parameter
+  pattern: (identifier) @binding
+  type: (_) @annotated)
+
+(let_declaration
+  pattern: (identifier) @binding
+  type: (_) @annotated)
+
+; An initializer states the type as plainly as an annotation does. A unit struct arrives as an
+; `identifier`, which the grammar cannot tell from reading a variable — and neither can this, so a
+; name that turns out to be a variable simply matches no type.
+(let_declaration
+  pattern: (identifier) @binding
+  value: (struct_expression name: (type_identifier) @annotated))
+
+(let_declaration
+  pattern: (identifier) @binding
+  value: (identifier) @annotated)

--- a/crates/core/src/dependency_resolver/mod.rs
+++ b/crates/core/src/dependency_resolver/mod.rs
@@ -1,4 +1,5 @@
 pub mod base_resolver;
+pub mod receiver_narrowing;
 pub mod trait_implementation;
 
 pub use base_resolver::DependencyResolver as DependencyResolverTrait;

--- a/crates/core/src/dependency_resolver/receiver_narrowing.rs
+++ b/crates/core/src/dependency_resolver/receiver_narrowing.rs
@@ -1,0 +1,252 @@
+//! Pointing `receiver.member` at the member the receiver's type declares.
+//!
+//! Two types may declare a member of the same name, and matching on the name alone links an access
+//! to every one of them — inventing a relationship with a type the code never mentions. The
+//! receiver's type is what tells them apart, and a single file knows it only where it is written
+//! down. Where it is not written down, nothing is claimed.
+//!
+//! Both languages ask the same three questions — which type declares this member, what does this
+//! access read from, and what is that receiver's type — so only the node names differ, and those
+//! arrive as a `Dialect`.
+
+use crate::models::{Definition, Usage};
+use crate::query::{self, NamedSpan};
+use std::collections::{HashMap, HashSet};
+use tree_sitter::Node;
+
+/// Queries locating the parts of a member access in one language.
+pub struct Queries {
+    /// Which type declares a member, as `@owner` and `@member`.
+    pub member_owners: &'static str,
+    /// What each access reads from, as `@receiver` and the `@accessed` member.
+    pub accesses: &'static str,
+    /// Bindings whose type the file states, as `@binding` and `@annotated`.
+    pub receiver_types: &'static str,
+    /// Where each type's body spans, as `@owner` and `@body`.
+    pub enclosing_bodies: &'static str,
+}
+
+/// What the node names of one language mean for a receiver.
+pub struct Dialect {
+    pub queries: Queries,
+    /// Kinds that wrap a receiver without changing what it is, such as a parenthesis or a borrow.
+    pub wrappers: &'static [&'static str],
+    /// Kinds naming the type the code sits inside: `this`, `self`.
+    pub enclosing: &'static [&'static str],
+    /// Kinds stating the receiver's type at the access, as their second named child: `a as First`.
+    pub stated: &'static [&'static str],
+}
+
+/// What each member access can be narrowed to, read off the file once.
+pub struct ReceiverNarrowing {
+    owner_by_member_position: HashMap<(usize, usize), String>,
+    /// Every member access, keyed by the position a `Usage` carries for it.
+    ///
+    /// Held separately from the types below so that "an access whose receiver's type is unknown" is
+    /// distinguishable from "not an access at all". The first must resolve to nothing; the second
+    /// must be left entirely alone, since most usages are not member accesses.
+    access_positions: HashSet<(usize, usize)>,
+    receiver_types_by_access: HashMap<(usize, usize), Vec<String>>,
+}
+
+impl ReceiverNarrowing {
+    pub fn new(dialect: &Dialect, source_code: &str, root_node: Node) -> Result<Self, String> {
+        let annotations = Annotations::read(dialect, source_code, root_node)?;
+
+        let accesses = query::map_pairs(
+            dialect.queries.accesses,
+            source_code,
+            root_node,
+            "receiver",
+            "accessed",
+            |receiver, accessed| {
+                Some((
+                    (
+                        accessed.start_position().row + 1,
+                        accessed.start_position().column + 1,
+                    ),
+                    annotations.types_of(dialect, receiver, source_code),
+                ))
+            },
+        )?;
+
+        Ok(Self {
+            owner_by_member_position: query::text_by_position(
+                dialect.queries.member_owners,
+                source_code,
+                root_node,
+                "owner",
+                "member",
+            )?,
+            access_positions: accesses.iter().map(|(position, _)| *position).collect(),
+            receiver_types_by_access: accesses
+                .into_iter()
+                .filter_map(|(position, types)| types.map(|types| (position, types)))
+                .collect(),
+        })
+    }
+
+    /// Keep the candidates the receiver's type declares.
+    ///
+    /// A usage that is not a member access is left alone, since the receiver's type has no bearing
+    /// on it. So is a single candidate: there is nothing to tell apart, and the receiver's type may
+    /// well be unknowable. Several candidates with an unknown receiver type yield nothing, since
+    /// every answer would be a guess and the wrong ones are edges to types the line never names.
+    pub fn narrow<'a>(
+        &self,
+        usage: &Usage,
+        candidates: Vec<&'a Definition>,
+    ) -> Vec<&'a Definition> {
+        let position = (usage.position.start_line, usage.position.start_column);
+
+        if candidates.len() <= 1 || !self.access_positions.contains(&position) {
+            return candidates;
+        }
+
+        let Some(owners) = self.receiver_types_by_access.get(&position) else {
+            return Vec::new();
+        };
+
+        candidates
+            .into_iter()
+            .filter(|candidate| {
+                self.owner_of(candidate)
+                    .is_some_and(|owner| owners.contains(owner))
+            })
+            .collect()
+    }
+
+    fn owner_of(&self, definition: &Definition) -> Option<&String> {
+        self.owner_by_member_position.get(&(
+            definition.position.start_line,
+            definition.position.start_column,
+        ))
+    }
+}
+
+/// Where the file states a type, which is the only way to know what a receiver is.
+struct Annotations {
+    types_by_binding: HashMap<String, Vec<String>>,
+    body_spans: Vec<NamedSpan>,
+}
+
+impl Annotations {
+    fn read(dialect: &Dialect, source_code: &str, root_node: Node) -> Result<Self, String> {
+        Ok(Self {
+            types_by_binding: merged(query::map_pairs(
+                dialect.queries.receiver_types,
+                source_code,
+                root_node,
+                "binding",
+                "annotated",
+                |binding, annotation| {
+                    Some((
+                        binding.utf8_text(source_code.as_bytes()).ok()?.to_string(),
+                        stated_type_names(&annotation, source_code),
+                    ))
+                },
+            )?),
+            body_spans: query::text_by_span(
+                dialect.queries.enclosing_bodies,
+                source_code,
+                root_node,
+                "owner",
+                "body",
+            )?,
+        })
+    }
+
+    /// The types this receiver expression may have. A union states several, and the member may be
+    /// declared by any of them.
+    fn types_of(
+        &self,
+        dialect: &Dialect,
+        receiver: Node,
+        source_code: &str,
+    ) -> Option<Vec<String>> {
+        let kind = receiver.kind();
+
+        if kind == "identifier" {
+            return self
+                .types_by_binding
+                .get(receiver.utf8_text(source_code.as_bytes()).ok()?)
+                .cloned();
+        }
+        if dialect.enclosing.contains(&kind) {
+            return self
+                .enclosing_type(receiver.start_position().row + 1)
+                .map(|owner| vec![owner]);
+        }
+        // A cast states the type at the access itself, which is as good as an annotation on the
+        // binding and better than nothing when the binding has none.
+        if dialect.stated.contains(&kind) {
+            return Some(type_names(&receiver.named_child(1)?, source_code));
+        }
+        if dialect.wrappers.contains(&kind) {
+            return self.types_of(dialect, receiver.named_child(0)?, source_code);
+        }
+
+        // A chained `a.b.c` or a call's result is an expression whose type the file does not state,
+        // so nothing is claimed for it.
+        None
+    }
+
+    /// The innermost body containing the line, so a nested type wins over the one it sits in.
+    fn enclosing_type(&self, line: usize) -> Option<String> {
+        self.body_spans
+            .iter()
+            .filter(|(_, (start, end))| *start <= line && line <= *end)
+            .min_by_key(|(_, (start, end))| end - start)
+            .map(|(owner, _)| owner.clone())
+    }
+}
+
+/// Every type a binding is stated to have, rather than whichever the last match happened to state.
+///
+/// `let bound: Second = s;` states one through the annotation and one through the initializer, and
+/// keeping only one of them was losing whichever the query matched first. Each is genuinely stated at
+/// that line, and a name that is not a type matches no owner.
+fn merged(pairs: Vec<(String, Vec<String>)>) -> HashMap<String, Vec<String>> {
+    pairs
+        .into_iter()
+        .fold(HashMap::new(), |mut merged, (binding, types)| {
+            merged.entry(binding).or_default().extend(types);
+            merged
+        })
+}
+
+/// The type names something stated as a type, reading a bare name as one.
+///
+/// `let n = Numbers;` states the type by naming a unit struct, which the grammar gives as an
+/// `identifier` rather than a `type_identifier`. It cannot tell that from reading a variable, and
+/// neither can this — a name that turns out to be a variable matches no type and rules nothing out.
+fn stated_type_names(node: &Node, source_code: &str) -> Vec<String> {
+    let names = type_names(node, source_code);
+
+    match (names.is_empty(), node.kind()) {
+        (true, "identifier") => node
+            .utf8_text(source_code.as_bytes())
+            .map(|name| vec![name.to_string()])
+            .unwrap_or_default(),
+        _ => names,
+    }
+}
+
+/// The type names a type expression states.
+///
+/// Type arguments are not descended into: `Wrapper<Reader>` states `Wrapper`, and its members are
+/// the ones a receiver of that type reaches.
+fn type_names(node: &Node, source_code: &str) -> Vec<String> {
+    if node.kind() == "type_identifier" {
+        return node
+            .utf8_text(source_code.as_bytes())
+            .map(|name| vec![name.to_string()])
+            .unwrap_or_default();
+    }
+
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .filter(|child| child.kind() != "type_arguments")
+        .flat_map(|child| type_names(&child, source_code))
+        .collect()
+}

--- a/crates/core/src/languages/rust/dependency_resolver/mod.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/mod.rs
@@ -5,6 +5,7 @@ pub mod lifetime_resolver;
 pub mod method_resolver;
 pub mod module_resolver;
 pub mod nested_scope_resolver;
+pub mod receiver_narrowing;
 pub mod rust_dependency_resolver;
 pub mod trait_database;
 pub mod trait_implementation_resolver;

--- a/crates/core/src/languages/rust/dependency_resolver/receiver_narrowing.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/receiver_narrowing.rs
@@ -1,0 +1,28 @@
+//! The Rust node names a receiver can wear.
+//!
+//! Everything about narrowing a method call to the method its receiver's type declares is shared;
+//! see `crate::dependency_resolver::receiver_narrowing`.
+
+use crate::dependency_resolver::receiver_narrowing::{Dialect, Queries};
+
+pub const DIALECT: Dialect = Dialect {
+    queries: Queries {
+        member_owners: include_str!("../../../../queries/rust/method_owners.scm"),
+        accesses: include_str!("../../../../queries/rust/method_calls.scm"),
+        receiver_types: include_str!("../../../../queries/rust/receiver_types.scm"),
+        enclosing_bodies: include_str!("../../../../queries/rust/enclosing_impls.scm"),
+    },
+    // `(a)`, `&a` and `*a` are the same receiver wearing a wrapper, and `a?` is the value it
+    // unwraps to.
+    wrappers: &[
+        "parenthesized_expression",
+        "reference_expression",
+        "unary_expression",
+        "try_expression",
+    ],
+    // `self` names the type whose impl the call sits inside.
+    enclosing: &["self"],
+    // Rust states a receiver's type at a binding rather than at the access; `a as T` casts values,
+    // not references, so there is nothing to read here.
+    stated: &[],
+};

--- a/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
@@ -1,4 +1,5 @@
 use super::nested_scope_resolver::ScopeUtilities;
+use crate::dependency_resolver::receiver_narrowing::ReceiverNarrowing;
 use crate::dependency_resolver::DependencyResolverTrait;
 use crate::models::{
     scope::{CodeAnalysisContext, SymbolTable},
@@ -372,27 +373,32 @@ impl RustDependencyResolver {
     /// Basic fallback resolution for cases where advanced resolution fails
     fn resolve_basic_dependencies(
         &self,
-        _source_code: &str,
-        _root_node: Node,
+        source_code: &str,
+        root_node: Node,
         usage_nodes: &[Usage],
         definitions: &[Definition],
     ) -> Result<Vec<Dependency>, String> {
-        let mut all_dependencies = Vec::new();
+        // Read off the file once rather than per usage: every method call asks the same questions of
+        // it, and a malformed query must fail rather than quietly resolve nothing.
+        let narrowing =
+            ReceiverNarrowing::new(&super::receiver_narrowing::DIALECT, source_code, root_node)?;
 
-        for usage_node in usage_nodes {
-            let mut deps = self.resolve_single_dependency_with_scope_aware_external_filtering(
-                usage_node,
-                definitions,
-                usage_nodes,
-            );
-            all_dependencies.append(&mut deps);
-        }
-
-        Ok(all_dependencies)
+        Ok(usage_nodes
+            .iter()
+            .flat_map(|usage_node| {
+                self.resolve_single_dependency_with_scope_aware_external_filtering(
+                    &narrowing,
+                    usage_node,
+                    definitions,
+                    usage_nodes,
+                )
+            })
+            .collect())
     }
 
     fn resolve_single_dependency_with_scope_aware_external_filtering(
         &self,
+        narrowing: &ReceiverNarrowing,
         usage_node: &Usage,
         definitions: &[Definition],
         all_usage_nodes: &[Usage],
@@ -422,7 +428,9 @@ impl RustDependencyResolver {
         }
 
         // Proceed with normal resolution
-        if let Some(def) = self.find_closest_accessible_definition_basic(usage_node, definitions) {
+        if let Some(def) =
+            self.find_closest_accessible_definition_basic(narrowing, usage_node, definitions)
+        {
             let source_line = usage_node.position.line_number();
             let target_line = def.line_number();
 
@@ -445,6 +453,7 @@ impl RustDependencyResolver {
 
     fn find_closest_accessible_definition_basic<'a>(
         &self,
+        narrowing: &ReceiverNarrowing,
         usage: &Usage,
         definitions: &'a [Definition],
     ) -> Option<&'a Definition> {
@@ -454,6 +463,10 @@ impl RustDependencyResolver {
             .iter()
             .filter(|d| d.name == usage.name && self.is_accessible_basic(usage, d))
             .collect();
+
+        // `receiver.method()` reaches only what the receiver's type declares, so the priority logic
+        // below chooses among those rather than among every method sharing the name.
+        let matching_definitions = narrowing.narrow(usage, matching_definitions);
 
         if matching_definitions.is_empty() {
             return None;

--- a/crates/core/src/languages/typescript/dependency_resolver/method_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/method_resolver.rs
@@ -1,4 +1,4 @@
-use super::receiver_narrowing::ReceiverNarrowing;
+use crate::dependency_resolver::receiver_narrowing::ReceiverNarrowing;
 use crate::models::{Definition, Dependency, Type, Usage, UsageKind};
 use std::collections::HashMap;
 use tree_sitter::Node;

--- a/crates/core/src/languages/typescript/dependency_resolver/receiver_narrowing.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/receiver_narrowing.rs
@@ -1,187 +1,23 @@
-//! Pointing `receiver.member` at the member the receiver's type declares.
+//! The TypeScript node names a receiver can wear.
 //!
-//! Two types may declare a member of the same name, and matching on the name alone links an access
-//! to both — inventing a relationship with a type the code never mentions. The receiver's type is
-//! what tells them apart, and a single file knows it only where it is written down: an annotated
-//! parameter or variable, an `as` at the access itself, or `this` inside a class. Where it is not
-//! written down, nothing is claimed.
+//! Everything about narrowing a member access to the member its receiver's type declares is shared;
+//! see `crate::dependency_resolver::receiver_narrowing`.
 
-use crate::models::{Definition, Usage};
-use crate::query::{self, NamedSpan};
-use std::collections::HashMap;
-use tree_sitter::Node;
+use crate::dependency_resolver::receiver_narrowing::{Dialect, Queries};
 
-const MEMBER_OWNERS: &str = include_str!("../../../../queries/typescript/member_owners.scm");
-const RECEIVER_TYPES: &str = include_str!("../../../../queries/typescript/receiver_types.scm");
-const ENCLOSING_CLASSES: &str =
-    include_str!("../../../../queries/typescript/enclosing_classes.scm");
-const MEMBER_ACCESSES: &str = include_str!("../../../../queries/typescript/member_accesses.scm");
-
-/// What each member access can be narrowed to, read off the file once.
-pub struct ReceiverNarrowing {
-    owner_by_member_position: HashMap<(usize, usize), String>,
-    /// The types the receiver of each access may have, keyed by the accessed member's position,
-    /// which is what a `Usage` carries.
-    receiver_types_by_access: HashMap<(usize, usize), Vec<String>>,
-}
-
-impl ReceiverNarrowing {
-    pub fn new(source_code: &str, root_node: Node) -> Result<Self, String> {
-        let annotations = Annotations::read(source_code, root_node)?;
-
-        Ok(Self {
-            owner_by_member_position: query::text_by_position(
-                MEMBER_OWNERS,
-                source_code,
-                root_node,
-                "owner",
-                "member",
-            )?,
-            receiver_types_by_access: query::map_pairs(
-                MEMBER_ACCESSES,
-                source_code,
-                root_node,
-                "receiver",
-                "accessed",
-                |receiver, accessed| {
-                    Some((
-                        (
-                            accessed.start_position().row + 1,
-                            accessed.start_position().column + 1,
-                        ),
-                        annotations.types_of(receiver, source_code)?,
-                    ))
-                },
-            )?
-            .into_iter()
-            .collect(),
-        })
-    }
-
-    /// Keep the candidates the receiver's type declares.
-    ///
-    /// One candidate is left alone: there is nothing to tell apart, and the receiver's type may
-    /// well be unknowable. Several candidates with an unknown receiver type yield nothing, since
-    /// every answer would be a guess and the wrong ones are edges to types the line never names.
-    pub fn narrow<'a>(
-        &self,
-        usage: &Usage,
-        candidates: Vec<&'a Definition>,
-    ) -> Vec<&'a Definition> {
-        if candidates.len() <= 1 {
-            return candidates;
-        }
-
-        let Some(owners) = self
-            .receiver_types_by_access
-            .get(&(usage.position.start_line, usage.position.start_column))
-        else {
-            return Vec::new();
-        };
-
-        candidates
-            .into_iter()
-            .filter(|candidate| {
-                self.owner_of(candidate)
-                    .is_some_and(|owner| owners.contains(owner))
-            })
-            .collect()
-    }
-
-    fn owner_of(&self, definition: &Definition) -> Option<&String> {
-        self.owner_by_member_position.get(&(
-            definition.position.start_line,
-            definition.position.start_column,
-        ))
-    }
-}
-
-/// Where the file states a type, which is the only way to know what a receiver is.
-struct Annotations {
-    types_by_binding: HashMap<String, Vec<String>>,
-    class_spans: Vec<NamedSpan>,
-}
-
-impl Annotations {
-    fn read(source_code: &str, root_node: Node) -> Result<Self, String> {
-        Ok(Self {
-            types_by_binding: query::map_pairs(
-                RECEIVER_TYPES,
-                source_code,
-                root_node,
-                "binding",
-                "annotated",
-                |binding, annotation| {
-                    Some((
-                        binding.utf8_text(source_code.as_bytes()).ok()?.to_string(),
-                        type_names(&annotation, source_code),
-                    ))
-                },
-            )?
-            .into_iter()
-            .collect(),
-            class_spans: query::text_by_span(
-                ENCLOSING_CLASSES,
-                source_code,
-                root_node,
-                "owner",
-                "body",
-            )?,
-        })
-    }
-
-    /// The types this receiver expression may have. A union states several, and the member may be
-    /// declared by any of them.
-    fn types_of(&self, receiver: Node, source_code: &str) -> Option<Vec<String>> {
-        match receiver.kind() {
-            "identifier" => self
-                .types_by_binding
-                .get(receiver.utf8_text(source_code.as_bytes()).ok()?)
-                .cloned(),
-            "this" => self
-                .enclosing_class(receiver.start_position().row + 1)
-                .map(|class_name| vec![class_name]),
-            // `a as First` states the type at the access itself, which is as good as an annotation
-            // on the binding and better than nothing when the binding has none.
-            "as_expression" | "satisfies_expression" => {
-                Some(type_names(&receiver.named_child(1)?, source_code))
-            }
-            // `(a)`, `a!` and `-a` are the same receiver wearing a wrapper.
-            "parenthesized_expression" | "non_null_expression" | "unary_expression" => {
-                self.types_of(receiver.named_child(0)?, source_code)
-            }
-            // A chained `a.b.c` or a call's result is an expression whose type the file does not
-            // state, so nothing is claimed for it.
-            _ => None,
-        }
-    }
-
-    /// The innermost class whose body contains the line, so a nested class wins over the one it
-    /// sits in.
-    fn enclosing_class(&self, line: usize) -> Option<String> {
-        self.class_spans
-            .iter()
-            .filter(|(_, (start, end))| *start <= line && line <= *end)
-            .min_by_key(|(_, (start, end))| end - start)
-            .map(|(owner, _)| owner.clone())
-    }
-}
-
-/// The type names a type expression states.
-///
-/// Type arguments are not descended into: `Wrapper<Reader>` states `Wrapper`, and its members are
-/// the ones a receiver of that type reaches.
-fn type_names(node: &Node, source_code: &str) -> Vec<String> {
-    if node.kind() == "type_identifier" {
-        return node
-            .utf8_text(source_code.as_bytes())
-            .map(|name| vec![name.to_string()])
-            .unwrap_or_default();
-    }
-
-    (0..node.child_count())
-        .filter_map(|index| node.child(index))
-        .filter(|child| child.kind() != "type_arguments")
-        .flat_map(|child| type_names(&child, source_code))
-        .collect()
-}
+pub const DIALECT: Dialect = Dialect {
+    queries: Queries {
+        member_owners: include_str!("../../../../queries/typescript/member_owners.scm"),
+        accesses: include_str!("../../../../queries/typescript/member_accesses.scm"),
+        receiver_types: include_str!("../../../../queries/typescript/receiver_types.scm"),
+        enclosing_bodies: include_str!("../../../../queries/typescript/enclosing_classes.scm"),
+    },
+    // `(a)`, `a!` and `-a` are the same receiver wearing a wrapper.
+    wrappers: &[
+        "parenthesized_expression",
+        "non_null_expression",
+        "unary_expression",
+    ],
+    enclosing: &["this"],
+    stated: &["as_expression", "satisfies_expression"],
+};

--- a/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
@@ -8,7 +8,7 @@ use tree_sitter::Node;
 use super::accessor_direction::AccessorDirection;
 use super::method_resolver::MethodResolver;
 use super::module_resolver::ModuleResolver;
-use super::receiver_narrowing::ReceiverNarrowing;
+use crate::dependency_resolver::receiver_narrowing::ReceiverNarrowing;
 
 /// TypeScript-specific dependency resolver
 pub struct TypeScriptDependencyResolver {
@@ -237,7 +237,8 @@ impl DependencyResolverTrait for TypeScriptDependencyResolver {
     ) -> Result<Vec<Dependency>, String> {
         // Read off the file once rather than per usage: every member access asks the same questions
         // of it, and a malformed query must fail rather than quietly resolve nothing.
-        let narrowing = ReceiverNarrowing::new(source_code, root_node)?;
+        let narrowing =
+            ReceiverNarrowing::new(&super::receiver_narrowing::DIALECT, source_code, root_node)?;
         let direction = AccessorDirection::new(source_code, root_node)?;
 
         let mut all_dependencies: Vec<Dependency> = usage_nodes

--- a/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_advanced_generics_ir.snap
+++ b/crates/core/tests/integration/language/rust/dependency_resolver/snapshots/integration_tests__integration__language__rust__dependency_resolver__rust_integration_tests__dependency_resolver_advanced_generics_ir.snap
@@ -241,7 +241,6 @@ IntermediateRepresentation {
         Dependency { source_line: 9, target_line: 5, symbol: "Display", dependency_type: TypeReference, context: Some("TypeIdentifier:9:28") },
         Dependency { source_line: 10, target_line: 19, symbol: "clone", dependency_type: FunctionCall, context: Some("FieldExpression:10:18") },
         Dependency { source_line: 10, target_line: 9, symbol: "item", dependency_type: VariableUse, context: Some("Identifier:10:18") },
-        Dependency { source_line: 11, target_line: 25, symbol: "display", dependency_type: FunctionCall, context: Some("FieldExpression:11:5") },
         Dependency { source_line: 11, target_line: 10, symbol: "cloned", dependency_type: VariableUse, context: Some("Identifier:11:5") },
         Dependency { source_line: 18, target_line: 1, symbol: "Clone", dependency_type: TypeReference, context: Some("TypeIdentifier:18:6") },
         Dependency { source_line: 18, target_line: 14, symbol: "Item", dependency_type: TypeReference, context: Some("TypeIdentifier:18:16") },


### PR DESCRIPTION
close: #254

```rust
impl First  { fn value(&self) -> i32 { 1 } }   // L5
impl Second { fn value(&self) -> i32 { 2 } }   // L11

fn read_first(f: First) -> i32 { f.value() }    // L17 -> L5, correct
fn read_second(s: Second) -> i32 { s.value() }  // L21 -> L5, WRONG
```

#213 settled this for TypeScript. Rust had the same defect and was worse: it picked one candidate deterministically rather than emitting all of them, so every call but the one on the first-declared type was a **false positive** pointing into another type's impl.

## Shared rather than duplicated

Both languages ask the same three questions — which type declares this member, what does the access read from, what is that receiver's type — so only the node names differ. The logic moved to `crate::dependency_resolver::receiver_narrowing` beside `trait_implementation.rs`, and each language supplies a `Dialect`:

| | wrappers | enclosing | type stated at the access |
| --- | --- | --- | --- |
| TypeScript | `(a)`, `a!`, `-a` | `this` | `as`, `satisfies` |
| Rust | `(a)`, `&a`, `*a`, `a?` | `self` | — |

23 and 28 lines of dialect against 252 shared. TypeScript's behaviour is unchanged, which the harness confirms.

One structural change was needed: accesses are now held separately from the types they resolve to, so **"an access whose receiver's type is unknown" is distinguishable from "not an access at all"**. The first must resolve to nothing, the second must be left alone — which matters as soon as the narrowing sits on a general resolution path rather than only on a field-access one. Without it, 33 unrelated edges disappeared.

## Where Rust states a receiver's type

A parameter, a `let` annotation, a `let` whose initializer names a type, or `self` inside an impl. A unit-struct initializer (`let made = First;`) arrives as an `identifier` the grammar cannot tell from reading a variable — a name that turns out to be a variable matches no type and rules nothing out. An annotation and an initializer can both state a type for one binding (`let bound: Second = s;`), so what they state is merged rather than one overwriting the other.

## Three recorded expectations were wrong

The harness reported these as regressions; each was the fixture, not the fix:

- `fn measure(shape: impl Shape)` and `fn measure(shape: &dyn Shape)` state **the trait and nothing else**, so `shape.area()` reaches the trait's declaration. Both fixtures pointed at `Square`'s impl — the only answer available before the receiver's type was consulted, and a guess as soon as a second implementor existed.
- one snapshot loses `cloned.display()` → `Item::display`, where `let cloned = item.clone()` has a receiver typed by a return value. Unknown type, two candidates, so nothing — and what it lost pointed at `Item` from a line whose only stated bound is `T: Display`.

All three are now documented in `crates/accuracy/README.md`, since they look like lost edges and are not.

## Verification

- accuracy `562 / 562`, precision 1.000, recall 1.000 (545 → 562)
- `rust/method_receivers.rs` adds 17 expectations covering all five receiver forms
- `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

## Also probed, already correct

`macro_rules` with repetition and metavariables, `where Self: Sized`, blanket impls linking their method to the trait declaration, TypeScript call and construct signatures, labelled tuples, `infer`, and template literal types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved Rust method-call dependency resolution by using the receiver’s known type.
  - Method calls through traits now resolve to the trait declaration rather than an arbitrary implementation.
  - Calls with unknown receiver types no longer produce speculative dependencies when multiple declarations match.
  - Added support for typed parameters, local bindings, borrowed receivers, and enclosing implementation context.

- **Documentation**
  - Expanded guidance on Rust receiver types and method-resolution behavior.

- **Tests**
  - Added comprehensive Rust coverage and updated accuracy baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->