### PR TITLE
fix: resolve a shadowing binding's initializer to the previous binding

### DIFF
--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -155,6 +155,10 @@ definition. The chain, rather than a direct edge to the definition, is deliberat
 - transitive metrics recover the full chain anyway, so nothing is lost by going through it
 - it agrees with #87's proposal that import-like dependencies belong at the top scope level
 
+A `use` line names the declaration and creates a binding of it at one position, so the name refers
+to the declaration while the binding is what it produces. Without that distinction the line resolved
+to its own import and produced no edge at all.
+
 This was an open question when the harness was written, and `rust/imports.rs` now pins the
 answer. It is a decision rather than a fact about the language, so it is revisitable — but it
 should be revisited by changing that fixture, not by discovering that behaviour drifted.

--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -94,7 +94,7 @@
       "correct": 12,
       "missing": 0,
       "spurious": 0,
-      "duplicates": 1
+      "duplicates": 2
     },
     "rust/let_else.rs": {
       "expected": 12,
@@ -153,9 +153,9 @@
       "duplicates": 0
     },
     "rust/nested_scopes.rs": {
-      "expected": 5,
-      "detected": 5,
-      "correct": 5,
+      "expected": 10,
+      "detected": 10,
+      "correct": 10,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -230,7 +230,7 @@
       "correct": 14,
       "missing": 0,
       "spurious": 0,
-      "duplicates": 0
+      "duplicates": 2
     },
     "rust/variables.rs": {
       "expected": 7,
@@ -281,9 +281,9 @@
       "duplicates": 0
     },
     "typescript/block_scopes.ts": {
-      "expected": 3,
-      "detected": 3,
-      "correct": 3,
+      "expected": 5,
+      "detected": 5,
+      "correct": 5,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -418,11 +418,11 @@
     }
   },
   "total": {
-    "expected": 562,
-    "detected": 562,
-    "correct": 562,
+    "expected": 569,
+    "detected": 569,
+    "correct": 569,
     "missing": 0,
     "spurious": 0,
-    "duplicates": 27
+    "duplicates": 30
   }
 }

--- a/crates/accuracy/fixtures/rust/nested_scopes.rs
+++ b/crates/accuracy/fixtures/rust/nested_scopes.rs
@@ -19,3 +19,24 @@ fn nesting() -> i32 {
 
     inner() //~ depends: inner@16
 }
+
+// A binding is not among the candidates for its own initializer, so `let w = w + 1` reads the
+// previous `w` — including when that one is in an enclosing scope, and when the initializer is on a
+// line of its own.
+fn shadowing() -> i32 {
+    let w = 1;
+    {
+        let w = w + 1; //~ depends: w@27
+        let w =
+            w + 1; //~ depends: w@29
+        w //~ depends: w@30
+    }
+}
+
+// A closure parameter and a generic are declared on the same line as the body reading them, and both
+// are visible there — which is why the rule above is about the initializer rather than the line.
+fn same_line() -> i32 {
+    let x = 100;
+    let closure = |x: i32| x + 1;
+    closure(x) //~ depends: closure@40, x@39
+}

--- a/crates/accuracy/fixtures/typescript/block_scopes.ts
+++ b/crates/accuracy/fixtures/typescript/block_scopes.ts
@@ -13,3 +13,13 @@ function inner(): number {
 
 const outside = a; //~ depends: a@5
 const result = inner(); //~ depends: inner@7
+
+// A binding is not among the candidates for its own initializer, so `let x = x + 1` reads the
+// previous `x` even when that one is in an enclosing scope.
+function shadowing(): number {
+    let v = 1;
+    {
+        let v = v + 1; //~ depends: v@20
+        return v; //~ depends: v@22
+    }
+}

--- a/crates/core/queries/rust/own_initializers.scm
+++ b/crates/core/queries/rust/own_initializers.scm
@@ -1,0 +1,9 @@
+; Each `let` paired with its initializer, so that the binding can be kept out of the names its own
+; initializer reads.
+;
+; `let w = w + 1` reads the previous `w`, never the one being declared — the binding starts after the
+; statement. A pattern binding several names is matched once per name.
+
+(let_declaration
+  pattern: (identifier) @declared
+  value: (_) @initializer)

--- a/crates/core/queries/typescript/own_initializers.scm
+++ b/crates/core/queries/typescript/own_initializers.scm
@@ -1,0 +1,8 @@
+; Each declarator paired with its initializer, so that the binding can be kept out of the names its
+; own initializer reads.
+;
+; `let x = x + 1` reads the previous `x`, never the one being declared.
+
+(variable_declarator
+  name: (identifier) @declared
+  value: (_) @initializer)

--- a/crates/core/src/dependency_resolver/mod.rs
+++ b/crates/core/src/dependency_resolver/mod.rs
@@ -1,5 +1,6 @@
 pub mod base_resolver;
 pub mod receiver_narrowing;
+pub mod self_reference;
 pub mod trait_implementation;
 
 pub use base_resolver::DependencyResolver as DependencyResolverTrait;

--- a/crates/core/src/dependency_resolver/self_reference.rs
+++ b/crates/core/src/dependency_resolver/self_reference.rs
@@ -1,0 +1,90 @@
+//! Keeping a binding out of the names its own initializer reads.
+//!
+//! `let w = w + 1` reads the **previous** `w`: the binding starts after the statement, so it is not
+//! among the candidates for anything inside its own initializer. Where the previous one is in an
+//! enclosing scope, resolution must be allowed to look past the inner declaration and find it.
+//!
+//! Position alone cannot express this. The declaration is on the same line as the usage, to its left,
+//! in a scope the usage can see — exactly like a closure parameter in `|x| x + 1` and a generic in
+//! `impl<const N: usize> Buffer<N>`, both of which the usage *does* name. What distinguishes them is
+//! structural: the usage lies inside the declaration's own initializer. So it is read off the tree
+//! and recorded as a pair of positions.
+
+use crate::models::{Definition, Usage};
+use crate::query;
+use std::collections::{HashMap, HashSet};
+use tree_sitter::Node;
+
+type Position = (usize, usize);
+
+/// Which declaration each usage must not resolve to.
+pub struct SelfReference {
+    declared_by_usage: HashMap<Position, HashSet<Position>>,
+}
+
+impl SelfReference {
+    pub fn new(query_source: &str, source_code: &str, root_node: Node) -> Result<Self, String> {
+        let pairs = query::map_pairs(
+            query_source,
+            source_code,
+            root_node,
+            "declared",
+            "initializer",
+            |declared, initializer| Some((position(declared), read_positions(initializer))),
+        )?;
+
+        Ok(Self {
+            declared_by_usage: pairs.into_iter().fold(
+                HashMap::new(),
+                |mut by_usage, (declared, reads)| {
+                    reads.into_iter().for_each(|read| {
+                        by_usage.entry(read).or_default().insert(declared);
+                    });
+                    by_usage
+                },
+            ),
+        })
+    }
+
+    /// Whether this definition is one the usage cannot be naming: the binding whose initializer the
+    /// usage sits in, or the declaration the usage itself is.
+    ///
+    /// `use my_module::MY_CONST` both names the const and creates an import of it, at one position.
+    /// The name refers to the declaration, so the import it creates is not a candidate for it.
+    pub fn declares(&self, usage: &Usage, definition: &Definition) -> bool {
+        let same_node = usage.position.start_line == definition.position.start_line
+            && usage.position.start_column == definition.position.start_column;
+
+        same_node || self.inside_initializer(usage, definition)
+    }
+
+    fn inside_initializer(&self, usage: &Usage, definition: &Definition) -> bool {
+        self.declared_by_usage
+            .get(&(usage.position.start_line, usage.position.start_column))
+            .is_some_and(|declared| {
+                declared.contains(&(
+                    definition.position.start_line,
+                    definition.position.start_column,
+                ))
+            })
+    }
+}
+
+/// Every identifier an initializer reads, at any depth.
+fn read_positions(node: Node) -> Vec<Position> {
+    if matches!(node.kind(), "identifier" | "type_identifier") {
+        return vec![position(node)];
+    }
+
+    (0..node.child_count())
+        .filter_map(|index| node.child(index))
+        .flat_map(read_positions)
+        .collect()
+}
+
+fn position(node: Node) -> Position {
+    (
+        node.start_position().row + 1,
+        node.start_position().column + 1,
+    )
+}

--- a/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
@@ -1,5 +1,9 @@
 use super::nested_scope_resolver::ScopeUtilities;
 use crate::dependency_resolver::receiver_narrowing::ReceiverNarrowing;
+use crate::dependency_resolver::self_reference::SelfReference;
+
+/// Each `let` paired with its initializer, so a binding stays out of the names it reads.
+const OWN_INITIALIZERS: &str = include_str!("../../../../queries/rust/own_initializers.scm");
 use crate::dependency_resolver::DependencyResolverTrait;
 use crate::models::{
     scope::{CodeAnalysisContext, SymbolTable},
@@ -226,10 +230,18 @@ impl RustDependencyResolver {
 
         in_scope
             .iter()
-            .filter(|def| def.position.start_line < usage.position.start_line)
+            // Up to and including the usage's own line: a closure parameter and a generic are
+            // declared on the line their body reads them from. A binding declared *later* is not
+            // visible, so it is no longer the answer of last resort — only a hoisted declaration is.
+            .filter(|def| def.position.start_line <= usage.position.start_line)
             .max_by_key(|def| def.position.start_line)
             .copied()
-            .or_else(|| in_scope.first().copied())
+            .or_else(|| {
+                in_scope
+                    .iter()
+                    .find(|def| self.is_hoisted_basic(def))
+                    .copied()
+            })
     }
 
     /// The usage's own scope followed by its enclosing scopes, nearest first.
@@ -382,12 +394,14 @@ impl RustDependencyResolver {
         // it, and a malformed query must fail rather than quietly resolve nothing.
         let narrowing =
             ReceiverNarrowing::new(&super::receiver_narrowing::DIALECT, source_code, root_node)?;
+        let own = SelfReference::new(OWN_INITIALIZERS, source_code, root_node)?;
 
         Ok(usage_nodes
             .iter()
             .flat_map(|usage_node| {
                 self.resolve_single_dependency_with_scope_aware_external_filtering(
                     &narrowing,
+                    &own,
                     usage_node,
                     definitions,
                     usage_nodes,
@@ -399,6 +413,7 @@ impl RustDependencyResolver {
     fn resolve_single_dependency_with_scope_aware_external_filtering(
         &self,
         narrowing: &ReceiverNarrowing,
+        own: &SelfReference,
         usage_node: &Usage,
         definitions: &[Definition],
         all_usage_nodes: &[Usage],
@@ -429,7 +444,7 @@ impl RustDependencyResolver {
 
         // Proceed with normal resolution
         if let Some(def) =
-            self.find_closest_accessible_definition_basic(narrowing, usage_node, definitions)
+            self.find_closest_accessible_definition_basic(narrowing, own, usage_node, definitions)
         {
             let source_line = usage_node.position.line_number();
             let target_line = def.line_number();
@@ -454,6 +469,7 @@ impl RustDependencyResolver {
     fn find_closest_accessible_definition_basic<'a>(
         &self,
         narrowing: &ReceiverNarrowing,
+        own: &SelfReference,
         usage: &Usage,
         definitions: &'a [Definition],
     ) -> Option<&'a Definition> {
@@ -462,6 +478,9 @@ impl RustDependencyResolver {
         let matching_definitions: Vec<&Definition> = definitions
             .iter()
             .filter(|d| d.name == usage.name && self.is_accessible_basic(usage, d))
+            // A binding is not among the candidates for its own initializer, so `let w = w + 1`
+            // looks past it and finds the previous `w`.
+            .filter(|d| !own.declares(usage, d))
             .collect();
 
         // `receiver.method()` reaches only what the receiver's type declares, so the priority logic

--- a/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
@@ -9,6 +9,10 @@ use super::accessor_direction::AccessorDirection;
 use super::method_resolver::MethodResolver;
 use super::module_resolver::ModuleResolver;
 use crate::dependency_resolver::receiver_narrowing::ReceiverNarrowing;
+use crate::dependency_resolver::self_reference::SelfReference;
+
+/// Each declarator paired with its initializer, so a binding stays out of the names it reads.
+const OWN_INITIALIZERS: &str = include_str!("../../../../queries/typescript/own_initializers.scm");
 
 /// TypeScript-specific dependency resolver
 pub struct TypeScriptDependencyResolver {
@@ -240,11 +244,12 @@ impl DependencyResolverTrait for TypeScriptDependencyResolver {
         let narrowing =
             ReceiverNarrowing::new(&super::receiver_narrowing::DIALECT, source_code, root_node)?;
         let direction = AccessorDirection::new(source_code, root_node)?;
+        let own = SelfReference::new(OWN_INITIALIZERS, source_code, root_node)?;
 
         let mut all_dependencies: Vec<Dependency> = usage_nodes
             .iter()
             .flat_map(|usage| {
-                self.resolve_single_dependency(&narrowing, &direction, usage, definitions)
+                self.resolve_single_dependency(&narrowing, &direction, &own, usage, definitions)
             })
             .collect();
 
@@ -265,6 +270,7 @@ impl TypeScriptDependencyResolver {
         &self,
         narrowing: &ReceiverNarrowing,
         direction: &AccessorDirection,
+        own: &SelfReference,
         usage_node: &Usage,
         definitions: &[Definition],
     ) -> Vec<Dependency> {
@@ -288,6 +294,9 @@ impl TypeScriptDependencyResolver {
 
         let accessible: Vec<&Definition> = all_matching_definitions
             .into_iter()
+            // A binding is not among the candidates for its own initializer, so `let x = x + 1`
+            // looks past it and finds the previous `x`.
+            .filter(|def| !own.declares(usage_node, def))
             .filter(|def| !Self::is_member_reached_by_name(usage_node, def))
             .filter(|def| self.is_accessible_basic(usage_node, def))
             .filter(|def| self.module_resolver.is_valid_dependency(usage_node, def))

--- a/crates/core/tests/integration/language/rust/snapshots/integration_tests__integration__language__rust__use_statements_dependency_ir.snap
+++ b/crates/core/tests/integration/language/rust/snapshots/integration_tests__integration__language__rust__use_statements_dependency_ir.snap
@@ -118,7 +118,9 @@ IntermediateRepresentation {
     ],
     dependencies: [
         Dependency { source_line: 7, target_line: 1, symbol: "my_module", dependency_type: ModuleReference, context: Some("TypeIdentifier:7:5") },
+        Dependency { source_line: 7, target_line: 2, symbol: "MyStruct", dependency_type: TypeReference, context: Some("TypeIdentifier:7:16") },
         Dependency { source_line: 8, target_line: 1, symbol: "my_module", dependency_type: ModuleReference, context: Some("TypeIdentifier:8:5") },
+        Dependency { source_line: 8, target_line: 3, symbol: "my_function", dependency_type: FunctionCall, context: Some("TypeIdentifier:8:17") },
         Dependency { source_line: 8, target_line: 4, symbol: "MY_CONST", dependency_type: VariableUse, context: Some("TypeIdentifier:8:30") },
         Dependency { source_line: 9, target_line: 1, symbol: "my_module", dependency_type: ModuleReference, context: Some("TypeIdentifier:9:5") },
         Dependency { source_line: 10, target_line: 1, symbol: "my_module", dependency_type: ModuleReference, context: Some("TypeIdentifier:10:5") },


### PR DESCRIPTION
close: #251

```rust
fn nested_scope() -> i32 {
    let w = 1;          // L8
    {
        let w = w + 1;  // L10  ->  nothing; should be L8
        w               // L11  ->  L10, correct
    }
}
```

The inner declaration was the only candidate in the block's scope, so `find_map` stopped there and the resulting self-edge was dropped. TypeScript behaved the same way.

## Why the obvious fix failed, and what replaced it

#251 records the attempt: restricting the scope search's fallback to hoisted declarations fixes this and breaks `|x| x + 1` and `impl<const N: usize> Buffer<N>`, because **position cannot tell the three apart**. In all of them the declaration is on the same line as the usage, to its left, in a scope the usage can see — yet only the `let` is invisible.

What distinguishes it is structural: the usage lies inside the declaration's own initializer. So that is read off the tree and recorded as a pair of positions, next to `receiver_narrowing.rs` and shared by both languages (`let_declaration` in Rust, `variable_declarator` in TypeScript).

With the binding excluded from its own initializer, the fallback **can** be restricted — a `let` declared further down is not visible earlier, and only a hoisted declaration is. That needed the line filter to include the usage's own line, which is where a closure parameter and a generic are declared.

The multi-line `let` the issue also flagged is fixed by the same change, since it is now the structure rather than the line that decides:

```rust
let w =
    w + 1;      // now reads the previous w
```

## A second self-reference, found on the way

Widening the line filter surfaced that `use my_module::MY_CONST` was resolving to **the import it creates** rather than the const it names — both sit at one position. A name cannot refer to the declaration it is, so that case is excluded too, and two use statements gain the edge they should always have had:

```
+ 7 -> 2 MyStruct
+ 8 -> 3 my_function
```

This is the import chain the accuracy README already documents; those two links were simply absent. The README now says why.

## Verification

- accuracy `569 / 569`, precision 1.000, recall 1.000 (562 → 569)
- `rust/nested_scopes.rs` and `typescript/block_scopes.ts` pin shadowing in an enclosing scope, across a line break, and the two same-line declarations a usage *does* name
- one snapshot changes, **additions only**
- `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency detection for shadowed variables and same-line declarations in Rust and TypeScript.
  - Correctly resolves references inside initializers, including cases such as `let x = x + 1`, without treating the newly declared variable as its own dependency.
  - Improved handling of nested scopes, closures, aliases, and imported bindings.

- **Documentation**
  - Clarified how `use` statements create local bindings and dependency relationships.

- **Tests**
  - Expanded accuracy coverage and updated expected results for scope and import resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->