### PR TITLE
fix(typescript): link a getter to the getter it implements

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -265,9 +265,9 @@
       "duplicates": 1
     },
     "typescript/accessors.ts": {
-      "expected": 9,
-      "detected": 9,
-      "correct": 9,
+      "expected": 15,
+      "detected": 15,
+      "correct": 15,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -418,9 +418,9 @@
     }
   },
   "total": {
-    "expected": 569,
-    "detected": 569,
-    "correct": 569,
+    "expected": 575,
+    "detected": 575,
+    "correct": 575,
     "missing": 0,
     "spurious": 0,
     "duplicates": 30

--- a/crates/accuracy/fixtures/typescript/accessors.ts
+++ b/crates/accuracy/fixtures/typescript/accessors.ts
@@ -32,3 +32,21 @@ class Counter {
 
 const counter = new Counter(); //~ depends: Counter@9
 const observed = counter.value; //~ depends: counter@33, value@12
+
+// An interface declares a getter and a setter separately, and each is satisfied by its own half.
+interface Measured {
+    get value(): number;
+    set value(next: number);
+}
+
+class Gauge implements Measured { //~ depends: Measured@37
+    private held = 0;
+
+    get value(): number { //~ depends: value@38
+        return this.held; //~ depends: held@43
+    }
+
+    set value(next: number) { //~ depends: value@39
+        this.held = next; //~ depends: held@43, next@49
+    }
+}

--- a/crates/core/queries/typescript/accessors.scm
+++ b/crates/core/queries/typescript/accessors.scm
@@ -5,3 +5,8 @@
 
 (method_definition "get" name: (property_identifier) @getter)
 (method_definition "set" name: (property_identifier) @setter)
+
+; An interface declares them the same way, and a class getter satisfies the interface's getter rather
+; than its setter.
+(method_signature "get" name: (property_identifier) @getter)
+(method_signature "set" name: (property_identifier) @setter)

--- a/crates/core/src/dependency_resolver/trait_implementation.rs
+++ b/crates/core/src/dependency_resolver/trait_implementation.rs
@@ -12,6 +12,11 @@ pub struct Queries {
     pub implementations: &'static str,
     /// Methods a trait or interface declares, as `@method`, with its own name.
     pub declarations: &'static str,
+    /// Getters and setters, as `@getter` and `@setter`, where the language has them.
+    ///
+    /// A getter and a setter share a name, so without this a class getter would satisfy whichever of
+    /// the pair the interface happened to declare last.
+    pub accessors: Option<&'static str>,
     /// Types a trait, interface or class inherits, as `@super`, with the inheriting type's name.
     pub supertypes: &'static str,
 }
@@ -23,30 +28,92 @@ pub struct Queries {
 /// this relationship is derived from the structure of the implementing block rather than from name
 /// resolution.
 ///
-/// Matching is on the pair of declaring type and method name, so two traits declaring the same
-/// method resolve independently.
+/// Matching is on the declaring type, the member's name and, where a language has accessors, whether
+/// it reads or writes — so two traits declaring the same method resolve independently, and a getter
+/// satisfies a getter.
 pub fn resolve(
     queries: &Queries,
     source_code: &str,
     root_node: Node,
 ) -> Result<Vec<Dependency>, String> {
-    let declared = declarations(queries.declarations, source_code, root_node)?;
+    let roles = Roles::read(queries.accessors, source_code, root_node)?;
+    let declared = declarations(queries.declarations, source_code, root_node, &roles)?;
     let inherited = supertypes(queries.supertypes, source_code, root_node)?;
 
-    Ok(methods(queries.implementations, source_code, root_node)?
-        .iter()
-        .filter_map(|method| {
-            declaration_line(&declared, &inherited, method).map(|line| dependency(method, line))
-        })
-        .filter(|dependency| dependency.source_line != dependency.target_line)
-        .collect())
+    Ok(
+        methods(queries.implementations, source_code, root_node, &roles)?
+            .iter()
+            .filter_map(|method| {
+                declaration_line(&declared, &inherited, method).map(|line| dependency(method, line))
+            })
+            .filter(|dependency| dependency.source_line != dependency.target_line)
+            .collect(),
+    )
 }
 
-/// A method named within a trait or interface, or within one of its implementations.
+/// A member named within a trait or interface, or within one of its implementations.
 struct Method {
     type_name: String,
     name: String,
+    role: Role,
     line: usize,
+}
+
+/// Which half of an accessor pair a member is, where the language has them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Role {
+    Plain,
+    Getter,
+    Setter,
+}
+
+/// The accessor role of each member, by the position of its name.
+struct Roles {
+    getters: HashSet<(usize, usize)>,
+    setters: HashSet<(usize, usize)>,
+}
+
+impl Roles {
+    fn read(
+        query_source: Option<&str>,
+        source_code: &str,
+        root_node: Node,
+    ) -> Result<Self, String> {
+        let Some(query_source) = query_source else {
+            return Ok(Self {
+                getters: HashSet::new(),
+                setters: HashSet::new(),
+            });
+        };
+
+        Ok(Self {
+            getters: crate::query::captured_positions(
+                query_source,
+                source_code,
+                root_node,
+                "getter",
+            )?,
+            setters: crate::query::captured_positions(
+                query_source,
+                source_code,
+                root_node,
+                "setter",
+            )?,
+        })
+    }
+
+    fn of(&self, node: Node) -> Role {
+        let position = (
+            node.start_position().row + 1,
+            node.start_position().column + 1,
+        );
+
+        match position {
+            _ if self.getters.contains(&position) => Role::Getter,
+            _ if self.setters.contains(&position) => Role::Setter,
+            _ => Role::Plain,
+        }
+    }
 }
 
 /// The line declaring this method, looked up on the named type and then on what it inherits.
@@ -54,8 +121,10 @@ struct Method {
 /// The search is breadth first, so the nearest declaration wins when a type and one of its
 /// supertypes both declare the method. The visited set also keeps an inheritance cycle — invalid
 /// but parseable — from looping.
+type DeclarationKey = (String, String, Role);
+
 fn declaration_line(
-    declared: &HashMap<(String, String), usize>,
+    declared: &HashMap<DeclarationKey, usize>,
     inherited: &HashMap<String, Vec<String>>,
     method: &Method,
 ) -> Option<usize> {
@@ -67,7 +136,8 @@ fn declaration_line(
             continue;
         }
 
-        if let Some(line) = declared.get(&(type_name.to_string(), method.name.clone())) {
+        if let Some(line) = declared.get(&(type_name.to_string(), method.name.clone(), method.role))
+        {
             return Some(*line);
         }
 
@@ -83,10 +153,11 @@ fn declarations(
     query_source: &str,
     source_code: &str,
     root_node: Node,
-) -> Result<HashMap<(String, String), usize>, String> {
-    Ok(methods(query_source, source_code, root_node)?
+    roles: &Roles,
+) -> Result<HashMap<DeclarationKey, usize>, String> {
+    Ok(methods(query_source, source_code, root_node, roles)?
         .into_iter()
-        .map(|method| ((method.type_name, method.name), method.line))
+        .map(|method| ((method.type_name, method.name, method.role), method.line))
         .collect())
 }
 
@@ -117,21 +188,27 @@ fn supertypes(
     Ok(inherited)
 }
 
-fn methods(query_source: &str, source_code: &str, root_node: Node) -> Result<Vec<Method>, String> {
+fn methods(
+    query_source: &str,
+    source_code: &str,
+    root_node: Node,
+    roles: &Roles,
+) -> Result<Vec<Method>, String> {
     map_pairs(
         query_source,
         source_code,
         root_node,
         "type",
         "method",
-        |type_node, method_node| method(source_code, type_node, method_node),
+        |type_node, method_node| method(source_code, type_node, method_node, roles),
     )
 }
 
-fn method(source_code: &str, type_node: Node, method_node: Node) -> Option<Method> {
+fn method(source_code: &str, type_node: Node, method_node: Node, roles: &Roles) -> Option<Method> {
     Some(Method {
         type_name: type_text(source_code, type_node)?,
         name: text(source_code, method_node)?,
+        role: roles.of(method_node),
         line: method_node.start_position().row + 1,
     })
 }

--- a/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/trait_implementation_resolver.rs
@@ -26,6 +26,9 @@ const QUERIES: Queries = Queries {
             (associated_type name: (type_identifier) @method)
           ]))
     "#,
+    // Rust has no accessors: a getter and a setter would be two ordinary methods with different
+    // names.
+    accessors: None,
     // `trait Extended: Base` inherits Base's declarations, so an implementation of Extended can be
     // satisfying something Base declared.
     supertypes: r#"

--- a/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/interface_implementation_resolver.rs
@@ -58,6 +58,7 @@ const QUERIES: Queries = Queries {
             ]))
         ]
     "#,
+    accessors: Some(include_str!("../../../../queries/typescript/accessors.scm")),
     // `interface Extended extends Base` and `class Derived extends Base` both inherit
     // declarations, so a lookup that misses the named type continues into these.
     supertypes: r#"


### PR DESCRIPTION
close: #257

```typescript
interface Sized {
    get size(): number;          // L2
    set size(v: number);         // L3
}

class Box implements Sized {
    get size(): number { .. }    // L9  ->  L3, the SETTER
    set size(v: number) { .. }   // L13 ->  L3, right by accident
}
```

`trait_implementation.rs` paired on `(declaring type, member name)`. An interface's getter and setter are both `method_signature` with the same `name:` — `get`/`set` are anonymous tokens — so the two collapsed into one entry and the later one won.

The accessor role now joins the key. `queries/typescript/accessors.scm` already identified getters and setters by position for #235; extending it to `method_signature` covers the declaration side, and the role is `Plain` for everything else.

Rust supplies `accessors: None` — a getter and a setter there are two ordinary methods with different names, so nothing changes for it.

## Verification

- accuracy `575 / 575`, precision 1.000, recall 1.000 (569 → 575)
- `typescript/accessors.ts` had a pair on a class but none on an interface, so which half each implementation satisfied was unmeasured
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

Third instance of the shared-name family, after #235 (which half an access reaches) and #254 (which type a method belongs to).

## Also probed, already correct

Rust `<Small as Limit>::CAP`, associated consts through `T::CAP` and `Self::CAP`, closures returned from functions, `&dyn Fn`; TypeScript `#private` methods, static members and inheritance, and namespace merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)