### PR TITLE
fix(typescript): keep type and value namespaces apart

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -408,6 +408,14 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "typescript/type_and_value_names.ts": {
+      "expected": 10,
+      "detected": 10,
+      "correct": 10,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 3
+    },
     "typescript/variables.ts": {
       "expected": 5,
       "detected": 5,
@@ -418,11 +426,11 @@
     }
   },
   "total": {
-    "expected": 575,
-    "detected": 575,
-    "correct": 575,
+    "expected": 585,
+    "detected": 585,
+    "correct": 585,
     "missing": 0,
     "spurious": 0,
-    "duplicates": 30
+    "duplicates": 33
   }
 }

--- a/crates/accuracy/fixtures/typescript/type_and_value_names.ts
+++ b/crates/accuracy/fixtures/typescript/type_and_value_names.ts
@@ -1,0 +1,26 @@
+// One name declared in both namespaces.
+//
+// TypeScript keeps types and values apart, so an interface and a `const` may share a name and each is
+// invisible where the other belongs. A class, an enum and a namespace declare in both, which is why
+// the rule is about what a declaration introduces rather than about matching like to like. See #259.
+
+interface Setting {
+    level: number;
+}
+
+const Setting = { level: 1 };
+
+function read(s: Setting): number { //~ depends: Setting@7
+    return s.level + Setting.level; //~ depends: s@13, level@8, Setting@11
+}
+
+class Both {
+    kind = "both";
+}
+
+type Alias = Both; //~ depends: Both@17
+
+function useClass(b: Both): string { //~ depends: Both@17
+    const made: Both = new Both(); //~ depends: Both@17
+    return b.kind + made.kind; //~ depends: b@23, kind@18, made@24
+}

--- a/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
@@ -58,6 +58,26 @@ impl TypeScriptDependencyResolver {
             .resolve_struct_field_access(usage_node, definitions, narrowing)
     }
 
+    /// Whether this declaration can be named from the position this usage sits in.
+    ///
+    /// TypeScript keeps types and values in separate namespaces, so an interface and a `const` may
+    /// share a name and each is invisible where the other belongs. A class, an enum and a namespace
+    /// declare in both, which is why the rule is about what a declaration introduces rather than
+    /// about matching a type usage to a type declaration.
+    fn is_in_usage_namespace(usage: &Usage, definition: &Definition) -> bool {
+        use crate::models::DefinitionType::*;
+
+        match definition.definition_type {
+            InterfaceDefinition | TypeDefinition => {
+                usage.kind == crate::models::UsageKind::TypeIdentifier
+            }
+            VariableDefinition | ConstDefinition | FunctionDefinition => {
+                usage.kind != crate::models::UsageKind::TypeIdentifier
+            }
+            _ => true,
+        }
+    }
+
     /// Whether a member would be reached by its bare name.
     ///
     /// `receiver.member` reaches only what the receiver's type declares, which the field access
@@ -297,6 +317,7 @@ impl TypeScriptDependencyResolver {
             // A binding is not among the candidates for its own initializer, so `let x = x + 1`
             // looks past it and finds the previous `x`.
             .filter(|def| !own.declares(usage_node, def))
+            .filter(|def| Self::is_in_usage_namespace(usage_node, def))
             .filter(|def| !Self::is_member_reached_by_name(usage_node, def))
             .filter(|def| self.is_accessible_basic(usage_node, def))
             .filter(|def| self.module_resolver.is_valid_dependency(usage_node, def))


### PR DESCRIPTION
Part of #259 — the TypeScript half.

```typescript
interface T { v: number; }
const T = { v: 1 };            // L4

function f(x: T): number {     // L5  ->  L4, the const; should be L1
    return x.v + T.v;          // L6  ->  L4, correct
}
```

TypeScript keeps types and values in separate namespaces, so an interface and a `const` may share a name and each is invisible where the other belongs. The usage kinds already carried the distinction — `TypeIdentifier` at L5, `Identifier` at L6 — and nothing acted on it.

## The rule is about the declaration, not about matching like to like

| DefinitionType | type position | value position |
| --- | --- | --- |
| `InterfaceDefinition`, `TypeDefinition` | yes | no |
| `VariableDefinition`, `ConstDefinition`, `FunctionDefinition` | no | yes |
| `ClassDefinition`, `EnumDefinition`, `ModuleDefinition` | yes | yes |
| everything else, including imports | unchanged |

A class declares in both, so "a type usage resolves to a type declaration" would be wrong. Verified that `type Alias = Both`, `b: Both`, `new Both()` and `const made: Both` all still resolve, along with `E.A` and `N.k`.

## Verification

- accuracy `585 / 585`, precision 1.000, recall 1.000 (575 → 585)
- `typescript/type_and_value_names.ts` adds 10 expectations; no fixture had declared one name in both namespaces, which is why the harness read 1.000 while a type annotation resolved to a const
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

## Left for #259

Rust has the same defect by a different route: `mod T` beside `fn T` makes `T::V` resolve to the function. Rust's usage kinds do not distinguish a path head from a call target, so that half needs the path position rather than the usage kind, and is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)