### PR TITLE
fix(rust): resolve a path head to a module or type, not a same-named value

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -168,6 +168,14 @@
       "spurious": 0,
       "duplicates": 3
     },
+    "rust/path_head_names.rs": {
+      "expected": 9,
+      "detected": 9,
+      "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "rust/patterns.rs": {
       "expected": 14,
       "detected": 14,
@@ -426,9 +434,9 @@
     }
   },
   "total": {
-    "expected": 585,
-    "detected": 585,
-    "correct": 585,
+    "expected": 594,
+    "detected": 594,
+    "correct": 594,
     "missing": 0,
     "spurious": 0,
     "duplicates": 33

--- a/crates/accuracy/fixtures/rust/path_head_names.rs
+++ b/crates/accuracy/fixtures/rust/path_head_names.rs
@@ -1,0 +1,27 @@
+// One name declared as both a module and a function.
+//
+// A path head names a module or a type, never a function or a local, so `Setting::LEVEL` reaches the
+// module while `Setting()` reaches the function. A later segment can be anything, which is why the
+// distinction is about being reached through rather than about being in a path. See #259.
+
+mod Setting {
+    pub const LEVEL: i32 = 1;
+}
+
+fn Setting() -> i32 {
+    2
+}
+
+struct Holder;
+
+impl Holder { //~ depends: Holder@15
+    fn make() -> Holder { //~ depends: Holder@15
+        Holder //~ depends: Holder@15
+    }
+}
+
+fn read() -> i32 {
+    let held = Holder::make(); //~ depends: Holder@15, make@18
+    let _ = held; //~ depends: held@24
+    Setting() + Setting::LEVEL //~ depends: Setting@11, Setting@7, LEVEL@8
+}

--- a/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
+++ b/crates/core/src/languages/rust/dependency_resolver/rust_dependency_resolver.rs
@@ -443,9 +443,13 @@ impl RustDependencyResolver {
         }
 
         // Proceed with normal resolution
-        if let Some(def) =
-            self.find_closest_accessible_definition_basic(narrowing, own, usage_node, definitions)
-        {
+        if let Some(def) = self.find_closest_accessible_definition_basic(
+            narrowing,
+            own,
+            usage_node,
+            definitions,
+            all_usage_nodes,
+        ) {
             let source_line = usage_node.position.line_number();
             let target_line = def.line_number();
 
@@ -466,12 +470,29 @@ impl RustDependencyResolver {
         dependencies
     }
 
+    /// Whether this candidate is a value the usage cannot be naming because something is reached
+    /// through it.
+    fn is_value_reached_through(
+        &self,
+        usage: &Usage,
+        definition: &Definition,
+        all_usage_nodes: &[Usage],
+    ) -> bool {
+        use crate::models::DefinitionType::{FunctionDefinition, VariableDefinition};
+
+        matches!(
+            definition.definition_type,
+            FunctionDefinition | VariableDefinition
+        ) && self.is_path_head(usage, all_usage_nodes)
+    }
+
     fn find_closest_accessible_definition_basic<'a>(
         &self,
         narrowing: &ReceiverNarrowing,
         own: &SelfReference,
         usage: &Usage,
         definitions: &'a [Definition],
+        all_usage_nodes: &[Usage],
     ) -> Option<&'a Definition> {
         // Simple approach: find all matching definitions and apply priority logic
         // This matches the old implementation behavior more closely
@@ -481,6 +502,7 @@ impl RustDependencyResolver {
             // A binding is not among the candidates for its own initializer, so `let w = w + 1`
             // looks past it and finds the previous `w`.
             .filter(|d| !own.declares(usage, d))
+            .filter(|d| !self.is_value_reached_through(usage, d, all_usage_nodes))
             .collect();
 
         // `receiver.method()` reaches only what the receiver's type declares, so the priority logic
@@ -859,6 +881,18 @@ impl RustDependencyResolver {
             .any(|other| is_adjacent_segment(usage_node, other));
 
         has_preceding && has_following
+    }
+
+    /// Whether this usage is a segment that something else is reached through.
+    ///
+    /// A path head names a module or a type — never a function or a local — so `mod T` beside
+    /// `fn T` resolves `T::V` to the module. A later segment can be anything, which is why the
+    /// question is about having a follower rather than about being in a path at all.
+    fn is_path_head(&self, usage_node: &Usage, all_usage_nodes: &[Usage]) -> bool {
+        is_in_path(usage_node)
+            && all_usage_nodes
+                .iter()
+                .any(|other| is_adjacent_segment(usage_node, other))
     }
 }
 


### PR DESCRIPTION
close: #259 — the Rust half; the TypeScript half landed in #260.

```rust
mod Setting {
    pub const LEVEL: i32 = 1;   // L2
}
fn Setting() -> i32 { 2 }       // L4

fn read() -> i32 {
    Setting() + Setting::LEVEL  // L8
}
```

Both `Setting`s resolved to the **function**, so `Setting::LEVEL`'s head pointed at L4 instead of the module at L1.

Rust's usage kinds do not distinguish a path head from a call target — both are `Identifier` — so the fix uses the path position instead. A path head is a segment **something is reached through**, and it names a module or a type, never a function or a local. A later segment can be anything, which is why the question is about having a follower rather than about being in a path: `Holder::make()`'s last segment is a function and must keep resolving.

Both facts were already computed for other purposes — the usage's context says it is in a path, and adjacency across the `::` says which segment it is — so this reuses them rather than adding anything.

## Verification

- accuracy `594 / 594`, precision 1.000, recall 1.000 (585 → 594)
- `rust/path_head_names.rs` adds 9 expectations, including an associated function call so the tail case stays pinned
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)