### PR TITLE
fix: key a member access by its span, not its start

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -137,9 +137,9 @@
       "duplicates": 0
     },
     "rust/method_receivers.rs": {
-      "expected": 17,
-      "detected": 17,
-      "correct": 17,
+      "expected": 23,
+      "detected": 23,
+      "correct": 23,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -434,9 +434,9 @@
     }
   },
   "total": {
-    "expected": 594,
-    "detected": 594,
-    "correct": 594,
+    "expected": 600,
+    "detected": 600,
+    "correct": 600,
     "missing": 0,
     "spurious": 0,
     "duplicates": 33

--- a/crates/accuracy/fixtures/rust/method_receivers.rs
+++ b/crates/accuracy/fixtures/rust/method_receivers.rs
@@ -41,3 +41,16 @@ fn from_initializer() -> i32 {
 fn through_a_borrow(s: &Second) -> i32 { //~ depends: Second@9
     (*s).value() //~ depends: s@41, value@22
 }
+
+// A chained call's receiver is an expression whose type the file does not state, so the second call
+// is left unresolved. Both accesses begin at the same token — Rust records a method call at the start
+// of its receiver — so only their extent tells them apart.
+impl First { //~ depends: First@7
+    fn to_second(&self) -> Second { //~ depends: Second@9
+        Second //~ depends: Second@9
+    }
+}
+
+fn through_a_chain(f: First) -> i32 { //~ depends: First@7
+    f.to_second().value() //~ depends: f@54, to_second@49
+}

--- a/crates/core/src/dependency_resolver/receiver_narrowing.rs
+++ b/crates/core/src/dependency_resolver/receiver_narrowing.rs
@@ -40,14 +40,21 @@ pub struct Dialect {
 /// What each member access can be narrowed to, read off the file once.
 pub struct ReceiverNarrowing {
     owner_by_member_position: HashMap<(usize, usize), String>,
-    /// Every member access, keyed by the position a `Usage` carries for it.
+    /// Every member access, keyed by the span a `Usage` carries for it.
+    ///
+    /// The span rather than the start, because `a.to_b().shared()` nests two accesses that begin at
+    /// the same token — Rust records a method call at the start of its receiver, so only the end
+    /// tells the outer one from the inner.
     ///
     /// Held separately from the types below so that "an access whose receiver's type is unknown" is
     /// distinguishable from "not an access at all". The first must resolve to nothing; the second
     /// must be left entirely alone, since most usages are not member accesses.
-    access_positions: HashSet<(usize, usize)>,
-    receiver_types_by_access: HashMap<(usize, usize), Vec<String>>,
+    access_spans: HashSet<Span>,
+    receiver_types_by_access: HashMap<Span, Vec<String>>,
 }
+
+/// Where an access begins and ends.
+type Span = ((usize, usize), (usize, usize));
 
 impl ReceiverNarrowing {
     pub fn new(dialect: &Dialect, source_code: &str, root_node: Node) -> Result<Self, String> {
@@ -61,10 +68,7 @@ impl ReceiverNarrowing {
             "accessed",
             |receiver, accessed| {
                 Some((
-                    (
-                        accessed.start_position().row + 1,
-                        accessed.start_position().column + 1,
-                    ),
+                    span(accessed),
                     annotations.types_of(dialect, receiver, source_code),
                 ))
             },
@@ -78,10 +82,10 @@ impl ReceiverNarrowing {
                 "owner",
                 "member",
             )?,
-            access_positions: accesses.iter().map(|(position, _)| *position).collect(),
+            access_spans: accesses.iter().map(|(span, _)| *span).collect(),
             receiver_types_by_access: accesses
                 .into_iter()
-                .filter_map(|(position, types)| types.map(|types| (position, types)))
+                .filter_map(|(span, types)| types.map(|types| (span, types)))
                 .collect(),
         })
     }
@@ -97,13 +101,13 @@ impl ReceiverNarrowing {
         usage: &Usage,
         candidates: Vec<&'a Definition>,
     ) -> Vec<&'a Definition> {
-        let position = (usage.position.start_line, usage.position.start_column);
+        let accessed = usage_span(usage);
 
-        if candidates.len() <= 1 || !self.access_positions.contains(&position) {
+        if candidates.len() <= 1 || !self.access_spans.contains(&accessed) {
             return candidates;
         }
 
-        let Some(owners) = self.receiver_types_by_access.get(&position) else {
+        let Some(owners) = self.receiver_types_by_access.get(&accessed) else {
             return Vec::new();
         };
 
@@ -213,6 +217,23 @@ fn merged(pairs: Vec<(String, Vec<String>)>) -> HashMap<String, Vec<String>> {
             merged.entry(binding).or_default().extend(types);
             merged
         })
+}
+
+fn span(node: Node) -> Span {
+    (
+        (
+            node.start_position().row + 1,
+            node.start_position().column + 1,
+        ),
+        (node.end_position().row + 1, node.end_position().column + 1),
+    )
+}
+
+fn usage_span(usage: &Usage) -> Span {
+    (
+        (usage.position.start_line, usage.position.start_column),
+        (usage.position.end_line, usage.position.end_column),
+    )
 }
 
 /// The type names something stated as a type, reading a bare name as one.


### PR DESCRIPTION
close: #262

```rust
impl A { fn to_b(&self) -> B { B }  fn shared(&self) -> i32 { 1 } }   // L4, L5
impl B { fn shared(&self) -> i32 { 2 } }                              // L8

fn chained(a: A) -> i32 {
    a.to_b().shared()      // L11 -> L5, A::shared, from a receiver that is a B
}
```

The receiver of `.shared()` is `a.to_b()`, whose type the file does not state — so #254's rule says emit nothing.

## Cause

Rust records a method call at the **start of its receiver**, so line 11 holds two usages with identical starts:

```
usage 'shared' at 11:5 – 11:20
usage 'to_b'   at 11:5 – 11:11
```

`ReceiverNarrowing` keyed accesses by `(start_line, start_column)`, so `to_b`'s entry — receiver `a`, type known as `A` — overwrote `shared`'s, and the chained call inherited `["A"]`.

Keying by the whole span separates them. TypeScript is unaffected, since a member usage there is the property identifier itself, but the span is the right key for both.

## Verification

- accuracy `600 / 600`, precision 1.000, recall 1.000 (594 → 600)
- `rust/method_receivers.rs` chains between two types declaring one method name — `rust/method_chains.rs` has chains, but each name in it is declared once, so the collision could not produce a visible wrong answer
- every earlier receiver form re-checked: parameter, annotated `let`, initializer, `self`, borrow
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved method-call resolution for chained calls, producing more accurate results when receiver types are inferred from expressions.
  - Prevented incorrect matching of similar method accesses by using the complete access range.

- **Tests**
  - Added coverage for chained Rust method calls where the intermediate receiver type is not explicitly recorded.
  - Updated accuracy baselines to reflect the improved detection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->