### PR TITLE
fix(typescript): stop a declaration one scope deeper from being visible

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -289,9 +289,9 @@
       "duplicates": 0
     },
     "typescript/block_scopes.ts": {
-      "expected": 5,
-      "detected": 5,
-      "correct": 5,
+      "expected": 15,
+      "detected": 15,
+      "correct": 15,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -434,9 +434,9 @@
     }
   },
   "total": {
-    "expected": 600,
-    "detected": 600,
-    "correct": 600,
+    "expected": 610,
+    "detected": 610,
+    "correct": 610,
     "missing": 0,
     "spurious": 0,
     "duplicates": 33

--- a/crates/accuracy/fixtures/typescript/block_scopes.ts
+++ b/crates/accuracy/fixtures/typescript/block_scopes.ts
@@ -23,3 +23,33 @@ function shadowing(): number {
         return v; //~ depends: v@22
     }
 }
+
+// A `for` header, a `switch` case and a `while` body each scope what they declare, so a name reused
+// inside one of them is invisible outside it — and a sibling case cannot see the other's.
+const held = 1;
+
+function loops(): number {
+    let sum = 0;
+
+    for (let held = 0; held < 3; held++) {
+        sum += held; //~ depends: sum@32, held@34
+    }
+
+    while (sum < 9) { //~ depends: sum@32
+        const held = 2;
+        sum += held; //~ depends: sum@32, held@39
+    }
+
+    return sum + held; //~ depends: sum@32, held@29
+}
+
+function branches(k: number): number {
+    switch (k) { //~ depends: k@46
+        case 1: {
+            const held = 10;
+            return held; //~ depends: held@49
+        }
+        default:
+            return held; //~ depends: held@29
+    }
+}

--- a/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
@@ -126,12 +126,9 @@ impl TypeScriptDependencyResolver {
     fn is_in_scope_chain(&self, usage: &Usage, definition: &Definition) -> bool {
         let chain = self.usage_scope_chain(usage);
 
-        definition.scope_id.is_some_and(|def_scope| {
-            chain.contains(&def_scope)
-                || self
-                    .parent_scope(def_scope)
-                    .is_some_and(|parent| chain.contains(&parent))
-        })
+        definition
+            .scope_id
+            .is_some_and(|def_scope| chain.contains(&def_scope))
     }
 
     /// The usage's own scope followed by its enclosing scopes.
@@ -145,13 +142,6 @@ impl TypeScriptDependencyResolver {
         std::iter::once(usage_scope)
             .chain(self.symbol_table.scopes.get_parent_scopes(usage_scope))
             .collect()
-    }
-
-    fn parent_scope(&self, scope_id: crate::models::ScopeId) -> Option<crate::models::ScopeId> {
-        self.symbol_table
-            .scopes
-            .get_scope(scope_id)
-            .and_then(|scope| scope.parent)
     }
 
     fn is_hoisted_basic(&self, definition: &Definition) -> bool {


### PR DESCRIPTION
close: #265

```typescript
const shared = 1;                                  // L1

function classic(): number {
    for (let shared = 0; shared < 3; shared++) {   // L5
        total += shared;                            // L6 -> L5, correct
    }
    return total + shared;                          // L8 -> L5, WRONG
}

function switched(k: number): number {
    switch (k) {
        case 1: {
            const shared = 10;                      // L14
        }
        default:
            return shared;                          // L18 -> L14, WRONG
    }
}
```

## Cause

`is_in_scope_chain` accepted a definition whose scope's **parent** is in the usage's chain:

```rust
chain.contains(&def_scope)
    || self.parent_scope(def_scope).is_some_and(|parent| chain.contains(&parent))
```

The allowance was carried over from Rust, where a scope-creating item registers its own name inside the scope it creates. In TypeScript it means **any declaration one level deeper than the usage's scope is visible** — a `for` header's scope has the function as its parent, so its variable escapes; a `switch` case's block sits one level below the switch, so it escapes to a sibling case.

A `while` body was already correct, its declaration being two levels down rather than one — which is what made the other two visible as bugs.

Nothing in TypeScript needed the allowance: a class, interface, function, enum and namespace all reach `is_accessible_basic`'s hoisting exemption before the scope chain is consulted. Removing it leaves every fixture unchanged and `parent_scope` unused, so that goes too.

## How it was found

By measuring which grammar node kinds the fixtures reach — **89 of 183** for TypeScript, 93 of 163 for Rust. `for_statement`, `switch_statement`, `switch_case` and `while_statement` were all absent, which is why 600 expectations at precision 1.000 did not reach this.

## Verification

- accuracy `610 / 610`, precision 1.000, recall 1.000 (600 → 610)
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript dependency resolution for variables declared within `for`, `while`, and `switch` blocks.
  * Prevented references from incorrectly accessing identifiers outside their valid block scope.
* **Tests**
  * Added coverage for block-scoping behavior in TypeScript fixtures.
  * Updated accuracy baselines to reflect the expanded validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->