### PR TITLE
fix(rust): bind the names in a let chain

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -97,12 +97,12 @@
       "duplicates": 2
     },
     "rust/let_else.rs": {
-      "expected": 12,
-      "detected": 12,
-      "correct": 12,
+      "expected": 32,
+      "detected": 32,
+      "correct": 32,
       "missing": 0,
       "spurious": 0,
-      "duplicates": 0
+      "duplicates": 1
     },
     "rust/loops.rs": {
       "expected": 7,
@@ -434,11 +434,11 @@
     }
   },
   "total": {
-    "expected": 610,
-    "detected": 610,
-    "correct": 610,
+    "expected": 630,
+    "detected": 630,
+    "correct": 630,
     "missing": 0,
     "spurious": 0,
-    "duplicates": 33
+    "duplicates": 34
   }
 }

--- a/crates/accuracy/fixtures/rust/let_else.rs
+++ b/crates/accuracy/fixtures/rust/let_else.rs
@@ -19,3 +19,25 @@ fn main() {
     }
     let _ = read(slot); //~ depends: read@8, slot@16
 }
+
+// A `let` chain holds several conditions, so each binds its own names and the body reads all of them.
+fn both(first: Slot, second: Slot) -> i32 { //~ depends: Slot@3
+    if let Slot::Filled(a) = first //~ depends: Slot@3, Filled@4, first@24
+        && let Slot::Filled(b) = second //~ depends: Slot@3, Filled@4, second@24
+    {
+        a + b //~ depends: a@25, b@26
+    } else {
+        0
+    }
+}
+
+fn until_empty(mut slot: Slot) -> i32 { //~ depends: Slot@3
+    let mut total = 0;
+    while let Slot::Filled(step) = slot //~ depends: Slot@3, Filled@4, slot@34
+        && step > 0 //~ depends: step@36
+    {
+        total += step; //~ depends: total@35, step@36
+        slot = Slot::Empty; //~ depends: slot@34, Slot@3, Empty@5
+    }
+    total //~ depends: total@35
+}

--- a/crates/core/src/languages/rust/rust_node_extractors.rs
+++ b/crates/core/src/languages/rust/rust_node_extractors.rs
@@ -859,14 +859,12 @@ impl RustDefinitionExtractor {
                         }
                     }
                 }
-                "if_expression" | "while_expression" => {
-                    if let Some(condition) = parent.child_by_field_name("condition") {
-                        if condition.kind() == "let_condition" {
-                            if let Some(pattern_field) = condition.child_by_field_name("pattern") {
-                                if self.is_child_of(node, pattern_field) {
-                                    return true;
-                                }
-                            }
+                // `if let` and `while let`, chained or not: a chain holds several `let_condition`s,
+                // so asking about the condition itself misses every pattern in one.
+                "let_condition" => {
+                    if let Some(pattern_field) = parent.child_by_field_name("pattern") {
+                        if self.is_child_of(node, pattern_field) {
+                            return true;
                         }
                     }
                 }


### PR DESCRIPTION
close: #267

```rust
if let Some(m) = a         // L10
    && let Some(n) = b     // L11
{
    m + n                  // L13 -> nothing at all
}
```

Neither `m` nor `n` became a definition, so the body had nothing to reference. `while let ... && ...` was affected the same way; the unchained forms were fine.

## Cause

`is_pattern_binding` walked up to the `if_expression` and required its condition to **be** a `let_condition`:

```rust
"if_expression" | "while_expression" => {
    if let Some(condition) = parent.child_by_field_name("condition") {
        if condition.kind() == "let_condition" {
```

A chain is `condition: (let_chain (let_condition ...) (let_condition ...))`, so the test failed and every pattern in it was missed.

Asking about the `let_condition` directly covers both shapes, and a `while` as much as an `if` — the walk up from the identifier passes through it either way. The arm gets shorter as well as more correct.

## How it was found

By measuring which grammar node kinds the fixtures reach: `let_chain` was among the 70 Rust kinds no fixture contained. Same sweep that found #265.

## Verification

- accuracy `630 / 630`, precision 1.000, recall 1.000 (610 → 630)
- `rust/let_else.rs` grows from 12 to 32 expectations; it covered `let else`, `if let` and `while let`, none of them chained
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

## Also probed, already correct

`unsafe`, `async` and `loop` blocks (all `(block)` nodes, so already scoped), struct patterns with `..`, `ref` bindings, `x @ 3..=5`, or-patterns, assignment and compound assignment, and `Vec::<i32>::new()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)