### PR TITLE
fix(typescript): register an aliased import under its local name

### DIFF
--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -360,6 +360,14 @@
       "spurious": 0,
       "duplicates": 0
     },
+    "typescript/imports.ts": {
+      "expected": 10,
+      "detected": 10,
+      "correct": 10,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/inheritance.ts": {
       "expected": 6,
       "detected": 6,
@@ -434,9 +442,9 @@
     }
   },
   "total": {
-    "expected": 630,
-    "detected": 630,
-    "correct": 630,
+    "expected": 640,
+    "detected": 640,
+    "correct": 640,
     "missing": 0,
     "spurious": 0,
     "duplicates": 34

--- a/crates/accuracy/fixtures/typescript/imports.ts
+++ b/crates/accuracy/fixtures/typescript/imports.ts
@@ -1,0 +1,24 @@
+// Import forms and the local names they introduce.
+//
+// The declarations these names refer to live in other files, which single-file analysis cannot see,
+// so an import line has nothing to depend on. What it does is introduce a local name, and every
+// reference in this file depends on the import line — the same half of the chain that
+// `rust/imports.rs` records for a `use` statement.
+//
+// `helper as aid` introduces `aid` alone: `helper` is the other module's name for it and is not a
+// local name at all. See #269.
+
+import { Widget, helper as aid } from "./widgets";
+import type { Shape } from "./shapes";
+import Fallback from "./fallback";
+import * as everything from "./all";
+
+function build(s: Shape): Widget { //~ depends: Shape@12, Widget@11
+    const made = new Widget(); //~ depends: Widget@11
+    aid(made); //~ depends: aid@11, made@17
+    Fallback.init(); //~ depends: Fallback@13
+    everything.run(); //~ depends: everything@14
+    return made; //~ depends: made@17
+}
+
+const built = build({ sides: 3 } as unknown as Shape); //~ depends: build@16, Shape@12

--- a/crates/core/queries/typescript/definitions.scm
+++ b/crates/core/queries/typescript/definitions.scm
@@ -38,6 +38,9 @@
 (catch_clause parameter: (identifier) @definition.variable)
 (for_in_statement kind: _ left: (identifier) @definition.variable)
 
-(import_specifier name: (identifier) @definition.import)
+; An alias is the local name; without one the imported name is. `name:` when aliased belongs to the
+; other module and is not a local name at all, which the negated field says.
+(import_specifier alias: (identifier) @definition.import)
+(import_specifier !alias name: (identifier) @definition.import)
 
 (type_parameter name: (type_identifier) @definition.type_parameter)


### PR DESCRIPTION
close: #269

```typescript
import { helper as aid, plain } from "./m";   // L1
aid();                                         // L2 -> nothing
plain();                                        // L3 -> L1, correct
```

`aid` is the local name; `helper` is the other module's name for the same thing and is not a local name at all. The query captured `name:`, so `helper` became a declaration nothing could refer to and `aid` had none.

## A negated field says what two patterns cannot

The local name is `alias:` when there is one and `name:` when there is not. Two ordinary patterns cannot express that — the second matches the aliased case too — but `!field` can:

```scheme
(import_specifier alias: (identifier) @definition.import)
(import_specifier !alias name: (identifier) @definition.import)
```

Worth noting for elsewhere: "capture X except when Y is present" has come up twice before (#239, and the pattern `type:` field), both worked around with a reference-wins override. `!field` may be the cleaner tool there too.

## Verification

- accuracy `640 / 640`, precision 1.000, recall 1.000 (630 → 640)
- `typescript/imports.ts` is new — TypeScript had **no import fixture at all**, while Rust has `imports.rs`. It covers named, aliased, type-only, default and namespace imports
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

Found by the coverage sweep that also produced #265 and #267: `import_statement`, `import_specifier`, `named_imports`, `namespace_import` and `import_clause` were all among the TypeScript node kinds no fixture reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)