### PR TITLE
test(accuracy): pin the constructs probing found already correct

### DIFF
--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -131,6 +131,21 @@ annotations — a JSX attribute does reference the prop it names, a type paramet
 `super::X` does not depend on the module's declaration. When a fixture disagrees with the analyzer,
 check which one is wrong before filing.
 
+## Which constructs the fixtures reach
+
+Listing the named node kinds each grammar defines and subtracting those appearing in any fixture says
+what is unmeasured. It found three defects in a row — #265 (`for_statement`, `switch_case`), #267
+(`let_chain`) and #269 (`import_statement` and friends, where TypeScript had no import fixture at
+all) — because a construct no fixture contains is one nothing keeps honest.
+
+Coverage now stands at **107 of 163** Rust kinds and **119 of 183** TypeScript ones. Most of the
+remainder carries no names to resolve: literals, comments, `debugger_statement`, `shebang`, regex.
+
+The other use is the reverse. Probing turns up constructs that are *already correct*, and verifying
+one by hand leaves nothing behind — so those go into a fixture too, marked as such. Type-level
+operators, function types, higher-ranked bounds, qualified paths and member syntax are all pinned
+that way rather than re-derived the next time someone wonders.
+
 ## Auditing real code for self-consistency
 
 The fixtures measure correctness on cases written by hand, which is why they are small. A

--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -56,6 +56,14 @@
       "spurious": 0,
       "duplicates": 0
     },
+    "rust/function_types.rs": {
+      "expected": 15,
+      "detected": 15,
+      "correct": 15,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
     "rust/functions.rs": {
       "expected": 8,
       "detected": 8,
@@ -183,6 +191,14 @@
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
+    },
+    "rust/qualified_paths.rs": {
+      "expected": 12,
+      "detected": 12,
+      "correct": 12,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
     },
     "rust/structs.rs": {
       "expected": 18,
@@ -400,6 +416,14 @@
       "spurious": 0,
       "duplicates": 1
     },
+    "typescript/member_syntax.ts": {
+      "expected": 12,
+      "detected": 12,
+      "correct": 12,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 1
+    },
     "typescript/namespaces.ts": {
       "expected": 10,
       "detected": 10,
@@ -432,6 +456,14 @@
       "spurious": 0,
       "duplicates": 3
     },
+    "typescript/type_operators.ts": {
+      "expected": 15,
+      "detected": 15,
+      "correct": 15,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "typescript/variables.ts": {
       "expected": 5,
       "detected": 5,
@@ -442,11 +474,11 @@
     }
   },
   "total": {
-    "expected": 640,
-    "detected": 640,
-    "correct": 640,
+    "expected": 694,
+    "detected": 694,
+    "correct": 694,
     "missing": 0,
     "spurious": 0,
-    "duplicates": 34
+    "duplicates": 37
   }
 }

--- a/crates/accuracy/fixtures/rust/function_types.rs
+++ b/crates/accuracy/fixtures/rust/function_types.rs
@@ -1,0 +1,34 @@
+// Function types, higher-ranked bounds and an extern block.
+//
+// Each of these was checked by hand while probing and was already correct; the fixture is what keeps
+// it that way.
+
+struct Payload {
+    size: i32,
+}
+
+type Handler = fn(Payload) -> i32; //~ depends: Payload@6
+
+fn apply(h: Handler, p: Payload) -> i32 { //~ depends: Handler@10, Payload@6
+    h(p) //~ depends: h@12, p@12
+}
+
+fn boxed(f: Box<dyn Fn(Payload) -> i32>, p: Payload) -> i32 { //~ depends: Payload@6
+    f(p) //~ depends: f@16, p@16
+}
+
+fn ranked<F>(f: F) -> i32
+where
+    F: for<'a> Fn(&'a Payload) -> i32, //~ depends: F@20, Payload@6
+{
+    let made = Payload { size: 1 }; //~ depends: Payload@6, size@7
+    f(&made) //~ depends: f@20, made@24
+}
+
+extern "C" {
+    fn external(n: i32) -> i32;
+}
+
+fn calls_external() -> i32 {
+    unsafe { external(1) } //~ depends: external@29
+}

--- a/crates/accuracy/fixtures/rust/qualified_paths.rs
+++ b/crates/accuracy/fixtures/rust/qualified_paths.rs
@@ -1,0 +1,26 @@
+// Associated constants reached through a type, a parameter and `Self`.
+//
+// Each of these was checked by hand while probing and was already correct; the fixture is what keeps
+// it that way.
+
+trait Limit {
+    const CAP: i32;
+
+    fn combined<T: Limit>(other: T) -> i32 { //~ depends: Limit@6
+        T::CAP + Self::CAP //~ depends: T@9, CAP@7, Limit@6
+    }
+}
+
+struct Small;
+
+impl Limit for Small { //~ depends: Limit@6, Small@14
+    const CAP: i32 = 1; //~ depends: CAP@7
+}
+
+fn fully_qualified() -> i32 {
+    <Small as Limit>::CAP //~ depends: Small@14, Limit@6, CAP@17
+}
+
+fn plain_path() -> i32 {
+    Small::CAP //~ depends: Small@14, CAP@17
+}

--- a/crates/accuracy/fixtures/typescript/member_syntax.ts
+++ b/crates/accuracy/fixtures/typescript/member_syntax.ts
@@ -1,0 +1,37 @@
+// Ways of naming a member, and a decorator.
+//
+// Each of these was checked by hand while probing and was already correct; the fixture is what keeps
+// it that way.
+
+const registry = { first: 1 };
+const key = "first";
+
+function subscripts(): number {
+    return registry[key] + registry["first"]; //~ depends: registry@6, key@7
+}
+
+function logged(target: unknown, name: string): void {}
+
+class Decorated {
+    #hidden = 1;
+
+    @logged //~ depends: logged@13
+    method(): void {}
+
+    #compute(): number {
+        return this.#hidden * 2; //~ depends: #hidden@16
+    }
+
+    total(): number {
+        return this.#compute(); //~ depends: #compute@21
+    }
+
+    static origin = new Decorated(); //~ depends: Decorated@15
+    static make(): Decorated { //~ depends: Decorated@15
+        return Decorated.origin; //~ depends: Decorated@15, origin@29
+    }
+}
+
+function isDecorated(v: unknown): v is Decorated { //~ depends: Decorated@15
+    return v instanceof Decorated; //~ depends: v@35, Decorated@15
+}

--- a/crates/accuracy/fixtures/typescript/type_operators.ts
+++ b/crates/accuracy/fixtures/typescript/type_operators.ts
@@ -1,0 +1,37 @@
+// Type-level operators.
+//
+// Each of these was checked by hand while probing and was already correct; the fixture is what keeps
+// it that way.
+
+interface Shape {
+    kind: string;
+    size: number;
+}
+
+type Keys = keyof Shape; //~ depends: Shape@6
+
+type Sized = Shape["size"]; //~ depends: Shape@6
+
+type Boxed<T = Shape> = T | null; //~ depends: Shape@6
+
+type Renamed = { [K in Keys]: Shape[K] }; //~ depends: Keys@11, Shape@6
+
+type Narrowed<T> = T extends Shape ? number : string; //~ depends: Shape@6
+
+const sample: Shape = { kind: "a", size: 1 }; //~ depends: Shape@6
+
+type SameAsSample = typeof sample; //~ depends: sample@21
+
+type Greeting = `hello ${string}`;
+
+interface Callable {
+    (input: Shape): number; //~ depends: Shape@6
+    new (seed: number): Callable; //~ depends: Callable@27
+    readonly tags: readonly string[];
+}
+
+type Labelled = [first: Shape, second: number]; //~ depends: Shape@6
+
+function invoke(c: Callable, s: Shape): number { //~ depends: Callable@27, Shape@6
+    return c(s); //~ depends: c@35, s@35
+}


### PR DESCRIPTION
Probing for defects turns up far more constructs that work than ones that do not — and verifying one by hand leaves nothing behind. These four fixtures record what was checked while chasing #265, #267 and #269:

| Fixture | Covers |
| --- | --- |
| `rust/function_types.rs` | `type H = fn(T) -> i32`, `Box<dyn Fn>`, `for<'a>` bounds, `extern "C"` |
| `rust/qualified_paths.rs` | `T::CAP`, `Self::CAP`, `<Small as Limit>::CAP`, `Small::CAP` |
| `typescript/type_operators.ts` | `keyof`, `Shape["size"]`, mapped, conditional and template literal types, generic defaults, call and construct signatures, labelled tuples |
| `typescript/member_syntax.ts` | subscripts by variable and literal, decorators, `#private` methods, static members, `v is T` |

Every one was already correct. The point is that nothing was keeping them so.

## Coverage

Listing each grammar's named node kinds and subtracting those any fixture contains is what produced #265, #267 and #269. After this:

| | before | after |
| --- | --- | --- |
| Rust | 93 / 163 | **107 / 163** |
| TypeScript | 89 / 183 | **119 / 183** |

Most of the remainder carries no names to resolve — literals, comments, `debugger_statement`, `shebang`, regex.

The README now records both directions of the technique: what is unmeasured, and what was measured once by hand and should not have to be again.

- accuracy `694 / 694`, precision 1.000, recall 1.000 (640 → 694)
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accuracy coverage fixtures for advanced Rust function types and qualified paths.
  * Added TypeScript fixtures covering member syntax and advanced type operators.
* **Documentation**
  * Documented how fixture coverage is calculated and how additional fixtures improve defect detection and regression protection.
* **Tests**
  * Updated benchmark baselines, increasing tracked coverage from 640 to 694 validated constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->