### PR TITLE
fix(typescript): let an export name a declaration in either namespace

### DIFF
--- a/crates/accuracy/README.md
+++ b/crates/accuracy/README.md
@@ -142,7 +142,9 @@ Coverage now stands at **107 of 163** Rust kinds and **119 of 183** TypeScript o
 remainder carries no names to resolve: literals, comments, `debugger_statement`, `shebang`, regex.
 
 The other use is the reverse. Probing turns up constructs that are *already correct*, and verifying
-one by hand leaves nothing behind — so those go into a fixture too, marked as such. Type-level
+one by hand leaves nothing behind — so those go into a fixture too, marked as such. #272 is what that
+is for: the export forms had been probed and found correct, nothing pinned them, and #260 broke one
+of them two merges later without the harness noticing. Type-level
 operators, function types, higher-ranked bounds, qualified paths and member syntax are all pinned
 that way rather than re-derived the next time someone wonders.
 

--- a/crates/accuracy/baseline.json
+++ b/crates/accuracy/baseline.json
@@ -128,6 +128,14 @@
       "spurious": 0,
       "duplicates": 0
     },
+    "rust/macros_and_unions.rs": {
+      "expected": 12,
+      "detected": 12,
+      "correct": 12,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
     "rust/match_arms.rs": {
       "expected": 13,
       "detected": 13,
@@ -180,6 +188,14 @@
       "expected": 9,
       "detected": 9,
       "correct": 9,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "rust/pattern_forms.rs": {
+      "expected": 20,
+      "detected": 20,
+      "correct": 20,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -292,6 +308,14 @@
       "expected": 15,
       "detected": 15,
       "correct": 15,
+      "missing": 0,
+      "spurious": 0,
+      "duplicates": 0
+    },
+    "typescript/assertions_and_exports.ts": {
+      "expected": 17,
+      "detected": 17,
+      "correct": 17,
       "missing": 0,
       "spurious": 0,
       "duplicates": 0
@@ -474,9 +498,9 @@
     }
   },
   "total": {
-    "expected": 694,
-    "detected": 694,
-    "correct": 694,
+    "expected": 743,
+    "detected": 743,
+    "correct": 743,
     "missing": 0,
     "spurious": 0,
     "duplicates": 37

--- a/crates/accuracy/fixtures/rust/macros_and_unions.rs
+++ b/crates/accuracy/fixtures/rust/macros_and_unions.rs
@@ -1,0 +1,37 @@
+// A macro definition and a union.
+//
+// Each was checked by hand while probing and was already correct; the fixture is what keeps it that
+// way. `macros.rs` covers invoking a macro and the captures inside a format string.
+
+const BASE: i32 = 3;
+
+macro_rules! twice {
+    ($x:expr) => {
+        $x * 2 //~ depends: $x@9
+    };
+}
+
+fn expanded() -> i32 {
+    twice!(BASE) //~ depends: twice@8, BASE@6
+}
+
+union Raw {
+    bits: u32,
+}
+
+fn read_union(r: Raw) -> u32 { //~ depends: Raw@18
+    unsafe { r.bits } //~ depends: bits@19, r@22
+}
+
+struct Holder {
+    value: i32,
+}
+
+async fn fetch() -> Holder { //~ depends: Holder@26
+    Holder { value: 1 } //~ depends: Holder@26, value@27
+}
+
+async fn awaited() -> i32 {
+    let held = fetch().await; //~ depends: fetch@30
+    held.value //~ depends: value@27, held@35
+}

--- a/crates/accuracy/fixtures/rust/pattern_forms.rs
+++ b/crates/accuracy/fixtures/rust/pattern_forms.rs
@@ -1,0 +1,44 @@
+// Every pattern form that binds a name.
+//
+// Each was checked by hand while probing and was already correct; the fixture is what keeps it that
+// way. What a pattern reads rather than binds is covered by `patterns.rs` and `match_arms.rs`.
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+const LOW: i32 = 1;
+const HIGH: i32 = 9;
+
+fn slices(xs: &[i32]) -> i32 {
+    match xs { //~ depends: xs@14
+        [first, .., last] => first + last,
+        [only] => *only,
+        [] => 0,
+    }
+}
+
+fn references(p: &Point) -> i32 { //~ depends: Point@6
+    let Point { ref x, .. } = *p; //~ depends: Point@6, x@7, p@22
+    *x //~ depends: x@23
+}
+
+fn mutable(mut p: Point) -> i32 { //~ depends: Point@6
+    p.x += 1; //~ depends: x@7, p@27
+    p.x //~ depends: x@7, p@27
+}
+
+fn ranges(v: i32) -> i32 {
+    match v { //~ depends: v@32
+        LOW..=HIGH => 0, //~ depends: LOW@11, HIGH@12
+        bound @ 10..=20 => bound,
+        1 | 2 => 3,
+        _ => -1,
+    }
+}
+
+fn tuples(pair: (i32, Point)) -> i32 { //~ depends: Point@6
+    let (count, Point { y, .. }) = pair; //~ depends: Point@6, y@8, pair@41
+    count + y //~ depends: count@42, y@42
+}

--- a/crates/accuracy/fixtures/typescript/assertions_and_exports.ts
+++ b/crates/accuracy/fixtures/typescript/assertions_and_exports.ts
@@ -1,0 +1,47 @@
+// Casts, `this` typing, instantiation, override and nested namespaces, plus what an export names.
+//
+// Each was checked by hand while probing and was already correct; the fixture is what keeps it that
+// way.
+
+interface Spec {
+    size: number;
+}
+
+const raw = { size: 1 };
+
+const checked = raw satisfies Spec; //~ depends: raw@10, Spec@6
+const asserted = <Spec>raw; //~ depends: Spec@6, raw@10
+const cast = raw as Spec; //~ depends: raw@10, Spec@6
+
+class Chainable {
+    value = 1;
+
+    self(): this {
+        return this;
+    }
+}
+
+class Sub extends Chainable { //~ depends: Chainable@16
+    override self(): this { //~ depends: self@19
+        return this;
+    }
+}
+
+function generic<T>(v: T): T {
+    return v; //~ depends: v@30
+}
+
+const instantiated = generic<Spec>; //~ depends: generic@30, Spec@6
+
+namespace Outer {
+    export namespace Inner {
+        export const deep = 1;
+    }
+}
+
+const reached = Outer.Inner.deep; //~ depends: Outer@36, Inner@37
+
+export { raw }; //~ depends: raw@10
+export { raw as exposed }; //~ depends: raw@10
+export type { Spec }; //~ depends: Spec@6
+export default checked; //~ depends: checked@12

--- a/crates/core/queries/typescript/export_specifiers.scm
+++ b/crates/core/queries/typescript/export_specifiers.scm
@@ -1,0 +1,7 @@
+; Names an export clause exposes.
+;
+; `export { X }` names a local declaration whether that declaration is a type or a value, and
+; `export type { X }` reads as an ordinary identifier — so an export is the one position where the
+; two namespaces are not kept apart.
+
+(export_specifier name: (identifier) @exported)

--- a/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
+++ b/crates/core/src/languages/typescript/dependency_resolver/typescript_dependency_resolver.rs
@@ -10,6 +10,11 @@ use super::method_resolver::MethodResolver;
 use super::module_resolver::ModuleResolver;
 use crate::dependency_resolver::receiver_narrowing::ReceiverNarrowing;
 use crate::dependency_resolver::self_reference::SelfReference;
+use crate::query;
+
+/// Names an export clause exposes, which belong to either namespace.
+const EXPORT_SPECIFIERS: &str =
+    include_str!("../../../../queries/typescript/export_specifiers.scm");
 
 /// Each declarator paired with its initializer, so a binding stays out of the names it reads.
 const OWN_INITIALIZERS: &str = include_str!("../../../../queries/typescript/own_initializers.scm");
@@ -64,8 +69,18 @@ impl TypeScriptDependencyResolver {
     /// share a name and each is invisible where the other belongs. A class, an enum and a namespace
     /// declare in both, which is why the rule is about what a declaration introduces rather than
     /// about matching a type usage to a type declaration.
-    fn is_in_usage_namespace(usage: &Usage, definition: &Definition) -> bool {
+    fn is_in_usage_namespace(
+        exported: &std::collections::HashSet<(usize, usize)>,
+        usage: &Usage,
+        definition: &Definition,
+    ) -> bool {
         use crate::models::DefinitionType::*;
+
+        // An export names a local declaration of either kind, and `export type { X }` reads as an
+        // ordinary identifier, so the two namespaces are not kept apart there.
+        if exported.contains(&(usage.position.start_line, usage.position.start_column)) {
+            return true;
+        }
 
         match definition.definition_type {
             InterfaceDefinition | TypeDefinition => {
@@ -255,11 +270,20 @@ impl DependencyResolverTrait for TypeScriptDependencyResolver {
             ReceiverNarrowing::new(&super::receiver_narrowing::DIALECT, source_code, root_node)?;
         let direction = AccessorDirection::new(source_code, root_node)?;
         let own = SelfReference::new(OWN_INITIALIZERS, source_code, root_node)?;
+        let exported =
+            query::captured_positions(EXPORT_SPECIFIERS, source_code, root_node, "exported")?;
 
         let mut all_dependencies: Vec<Dependency> = usage_nodes
             .iter()
             .flat_map(|usage| {
-                self.resolve_single_dependency(&narrowing, &direction, &own, usage, definitions)
+                self.resolve_single_dependency(
+                    &narrowing,
+                    &direction,
+                    &own,
+                    &exported,
+                    usage,
+                    definitions,
+                )
             })
             .collect();
 
@@ -281,6 +305,7 @@ impl TypeScriptDependencyResolver {
         narrowing: &ReceiverNarrowing,
         direction: &AccessorDirection,
         own: &SelfReference,
+        exported: &std::collections::HashSet<(usize, usize)>,
         usage_node: &Usage,
         definitions: &[Definition],
     ) -> Vec<Dependency> {
@@ -307,7 +332,7 @@ impl TypeScriptDependencyResolver {
             // A binding is not among the candidates for its own initializer, so `let x = x + 1`
             // looks past it and finds the previous `x`.
             .filter(|def| !own.declares(usage_node, def))
-            .filter(|def| Self::is_in_usage_namespace(usage_node, def))
+            .filter(|def| Self::is_in_usage_namespace(exported, usage_node, def))
             .filter(|def| !Self::is_member_reached_by_name(usage_node, def))
             .filter(|def| self.is_accessible_basic(usage_node, def))
             .filter(|def| self.module_resolver.is_valid_dependency(usage_node, def))


### PR DESCRIPTION
close: #272

A regression I introduced in #260.

```typescript
interface Spec { size: number; }
const raw = { size: 1 };
export type { Spec };      // -> nothing; was -> the interface before #260
export { raw };            // -> the const, correct
```

#260 separates the type and value namespaces, filtering an `Identifier` usage away from type declarations. In `export type { Spec }` the grammar gives `Spec` as a plain `identifier`, so the usage reads as a value position and the interface was ruled out.

An export is the one position where the namespaces are **not** kept apart: `export { X }` names a local declaration whether it is a type or a value, and `export type { X }` is the same syntax with a modifier the usage kind does not carry. So an export specifier's name is exempt, by the same position-set method used for accessors and self-references.

## How it was found, and why that matters

While writing fixtures for constructs already verified **by hand**. The export forms had been probed and were correct *before* #260 landed; nothing pinned them, so the regression survived two merges unnoticed.

That is the argument for pinning verified-correct constructs and not only defects, and the README now says so with this as the example.

## Also pinned here

| Fixture | Covers |
| --- | --- |
| `rust/pattern_forms.rs` | slices with `..`, `ref`, `mut`, `LOW..=HIGH`, `x @ 10..=20`, or-patterns, a tuple holding a struct pattern |
| `rust/macros_and_unions.rs` | a `macro_rules!` definition with a metavariable, a union, `.await` |
| `typescript/assertions_and_exports.ts` | `satisfies`, `<T>x`, `as`, a `this` return type, `override`, `generic<Spec>`, nested namespaces, all four export forms |

## Verification

- accuracy `743 / 743`, precision 1.000, recall 1.000 (694 → 743)
- coverage of named grammar kinds: Rust **121 / 163**, TypeScript **126 / 183**
- no snapshot changes, `cargo test --workspace` green, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript dependency tracking for exported values and types, including `export type` specifiers.
  * More accurately distinguishes type and value namespaces when resolving TypeScript exports.

* **Tests**
  * Expanded accuracy coverage for Rust macros, unions, async code, and pattern matching.
  * Added TypeScript coverage for assertions, generics, namespaces, and named/default exports.
  * Updated accuracy baselines to reflect the expanded test coverage.

* **Documentation**
  * Clarified how fixture coverage captures changes involving merged updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->